### PR TITLE
chore: Swap Jekyll for github gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "jekyll"
+gem 'github-pages'


### PR DESCRIPTION
This will match the Jekyll version used by the GitHub pages deployment.
Just copied this over from https://github.com/canada-ca/digital-playbook-guide-numerique/blob/master/Gemfile