### PR TITLE
fix Contact URL field

### DIFF
--- a/_includes/codeForm.html
+++ b/_includes/codeForm.html
@@ -24,11 +24,11 @@
   <h2>{{ site.ContactCodeDesc[page.lang] }}</h2>
     <div class="form-group">
       <label for="enUrlContact">{{ site.URLContactCodeEN[page.lang] }}</label>
-      <input class="form-control" id="enUrlContact" name="enUrlContact" type="url" required="required"/>
+      <input class="form-control" id="enUrlContact" name="enUrlContact" type="url"/>
     </div>
     <div class="form-group">
       <label for="frUrlContact">{{ site.URLContactCodeFR[page.lang] }}</label>
-      <input class="form-control" id="frUrlContact" name="frUrlContact" type="url" required="required"/>
+      <input class="form-control" id="frUrlContact" name="frUrlContact" type="url"/>
     </div>
     <div class="form-group">
       <label for="emailContact" class="required" > {{ site.EmailContactCode[page.lang] }} <strong class="required">({{ site.MandatoryField[page.lang] }})</strong></label>


### PR DESCRIPTION
Contact url field becomes non-mandatory and it does not trigger a warning