### PR TITLE
Added notes for local development in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To test your changes locally, run `jekyll serve`. For example using Docker:
 
 > docker run -p 4000:4000 -v $(pwd):/srv/jekyll -it --rm jekyll/jekyll jekyll serve
 
+Note: For PowerShell users, replace the parentheses with brackets (Change ```$(pwd)``` to ```${pwd}```)
+
 Site will be available at: http://localhost:4000/ore-ero/
 ______________________
 
@@ -61,5 +63,7 @@ Sauf indication contraire, le code source de ce projet est protégé par le droi
 Pour tester vos modifications localement, exécuter `jekyll serve`. Par exemple avec Docker:
 
 > docker run -p 4000:4000 -v $(pwd):/srv/jekyll -it --rm jekyll/jekyll jekyll serve
+
+Remarque: pour les utilisateurs de PowerShell, remplacez les parenthèses par des crochets (Modifiez ```$(pwd)``` en ```${pwd}```)
 
 Le site sera disponible au: http://localhost:4000/ore-ero/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ To test your changes locally, run `jekyll serve`. For example using Docker:
 
 > docker run -p 4000:4000 -v $(pwd):/srv/jekyll -it --rm jekyll/jekyll jekyll serve
 
-Note: For PowerShell users, replace the parentheses with brackets (Change ```$(pwd)``` to ```${pwd}```)
+Notes:
+- For PowerShell users, replace the parentheses with brackets (Change ```$(pwd)``` to ```${pwd}```)
+- If Jekyll is not automatically regenerating the site after files are modified, add the build command flags: ```--watch``` and ```--force_polling``` to the end of the above command
 
 Site will be available at: http://localhost:4000/ore-ero/
 ______________________
@@ -64,6 +66,8 @@ Pour tester vos modifications localement, exécuter `jekyll serve`. Par exemple 
 
 > docker run -p 4000:4000 -v $(pwd):/srv/jekyll -it --rm jekyll/jekyll jekyll serve
 
-Remarque: pour les utilisateurs de PowerShell, remplacez les parenthèses par des crochets (Modifiez ```$(pwd)``` en ```${pwd}```)
+Remarques:
+- Pour les utilisateurs de PowerShell, remplacez les parenthèses par des crochets (Modifiez ```$(pwd)``` en ```${pwd}```)
+- Si Jekyll ne régénère pas automatiquement le site une fois les fichiers modifiés, ajoutez les indicateurs: ```--watch``` et ```--force_polling``` à la fin de la commande ci-dessus
 
 Le site sera disponible au: http://localhost:4000/ore-ero/


### PR DESCRIPTION
Added some development notes in the README for PowerShell users and also Jekyll regeneration. My French is not the greatest (I used Google translate) so if someone could verify/correct it, that'd be great!

Notes:
- Docker throws an ```invalid reference format``` error when using ```$(pwd)``` instead of ```${pwd}``` on PowerShell
- For some reason, on my Windows 10 environment the local site was not regenerating when I modified files. I tested on a Linux environment (Ubuntu 18.04) and auto-regeneration seems to work fine. Specifying the *watch* and *force poll* [build command flags](https://jekyllrb.com/docs/configuration/options/) enabled auto-regeneration for the Windows environment.