### PR TITLE
Display an alert when submitting OSC form

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ To test your changes locally, run `jekyll serve`. For example using Docker:
 > docker run -p 4000:4000 -v $(pwd):/srv/jekyll -it --rm jekyll/jekyll jekyll serve
 
 Notes:
-- For PowerShell users, replace the parentheses with brackets (Change ```$(pwd)``` to ```${pwd}```)
-- If Jekyll is not automatically regenerating the site after files are modified, add the build command flags: ```--watch``` and ```--force_polling``` to the end of the above command
+- For PowerShell users, replace the parentheses with brackets (Change `$(pwd)` to `${pwd}`)
+- If Jekyll is not automatically regenerating the site after files are modified, add the build command flags: `--watch` and `--force_polling` to the end of the above command
 
 Site will be available at: http://localhost:4000/ore-ero/
 ______________________
@@ -67,7 +67,7 @@ Pour tester vos modifications localement, exécuter `jekyll serve`. Par exemple 
 > docker run -p 4000:4000 -v $(pwd):/srv/jekyll -it --rm jekyll/jekyll jekyll serve
 
 Remarques:
-- Pour les utilisateurs de PowerShell, remplacez les parenthèses par des crochets (Modifiez ```$(pwd)``` en ```${pwd}```)
-- Si Jekyll ne régénère pas automatiquement le site une fois les fichiers modifiés, ajoutez les indicateurs: ```--watch``` et ```--force_polling``` à la fin de la commande ci-dessus
+- Pour les utilisateurs de PowerShell, remplacez les parenthèses par des crochets (Modifiez `$(pwd)` en `${pwd}`)
+- Si Jekyll ne régénère pas automatiquement le site une fois les fichiers modifiés, ajoutez les indicateurs: `--watch` et `--force_polling` à la fin de la commande ci-dessus
 
 Le site sera disponible au: http://localhost:4000/ore-ero/

--- a/_config.yml
+++ b/_config.yml
@@ -414,6 +414,9 @@ FormSubmissionInProgress:
 FormSubmissionFail:
   en: Something went wrong! Unable to submit form.
   fr: Quelque chose s'est mal passé! Impossible de soumettre le formulaire.
+FormSubmissionSuccess:
+  en: Form was submitted!
+  fr: Le formulaire a été soumis!
 
 # Open Soruce Software (Schema and Form)
 SchemaVersionOssDesc:

--- a/_config.yml
+++ b/_config.yml
@@ -408,6 +408,13 @@ VersionCodeDesc:
   en: The latest version for this project. For example, 1.0.0.
   fr: La version de ce projet. Par  exemple, 1.0.0.
 
+FormSubmissionInProgress:
+  en: The form is being submitted...
+  fr: Le formulaire est en cours de soumission...
+FormSubmissionFail:
+  en: Something went wrong! Unable to submit form.
+  fr: Quelque chose s'est mal passé! Impossible de soumettre le formulaire.
+
 # Open Soruce Software (Schema and Form)
 SchemaVersionOssDesc:
   en: The version of the ORE metadata schema for open source software.

--- a/_includes/codeForm.html
+++ b/_includes/codeForm.html
@@ -249,6 +249,7 @@
     </div>
   
   <button id="prbotSubmit" type="button" class="btn btn-primary">Submit</button>
+  <button id="codeFormReset" type="reset" class="btn btn-default">Reset</button>
 
   <h3 id="prbotSubmitAlertInProgress" class="alert alert-warning" style='display: none'>
     <p>{{ site.FormSubmissionInProgress[page.lang]}}</p>

--- a/_includes/codeForm.html
+++ b/_includes/codeForm.html
@@ -259,7 +259,7 @@
       <b>{{ site.FormSubmissionFail[page.lang]}}</b>
     </div>
     <div id="prbotSubmitAlertSuccess" class="alert alert-success" style="display: none">
-      <b3>{{ site.FormSubmissionSuccess[page.lang]}}</b>
+      <b>{{ site.FormSubmissionSuccess[page.lang]}}</b>
     </div>
   </div>
 

--- a/_includes/codeForm.html
+++ b/_includes/codeForm.html
@@ -254,9 +254,12 @@
   <h3 id="prbotSubmitAlertInProgress" class="alert alert-warning" style='display: none'>
     <p>{{ site.FormSubmissionInProgress[page.lang]}}</p>
   </h3>
-
   <h3 id="prbotSubmitAlertFail" class="alert alert-danger" style='display: none'>
     <p>{{ site.FormSubmissionFail[page.lang]}}</p>
   </h3>
+  <h3 id="prbotSubmitAlertSuccess" class="alert alert-success" style='display: none'>
+    <p>{{ site.FormSubmissionSuccess[page.lang]}}</p>
+  </h3>
+
   </form>
   </div>

--- a/_includes/codeForm.html
+++ b/_includes/codeForm.html
@@ -251,15 +251,15 @@
   <button id="prbotSubmit" type="button" class="btn btn-primary">Submit</button>
   <button id="codeFormReset" type="reset" class="btn btn-default">Reset</button>
 
-  <div style='margin-top: 10px'>
-    <div id="prbotSubmitAlertInProgress" class="alert alert-warning" style='display: none'>
-      <h3>{{ site.FormSubmissionInProgress[page.lang]}}</h3>
+  <div style="margin-top: 10px">
+    <div id="prbotSubmitAlertInProgress" class="alert alert-warning" style="display: none">
+      <b>{{ site.FormSubmissionInProgress[page.lang]}}</b>
     </div>
-    <div id="prbotSubmitAlertFail" class="alert alert-danger" style='display: none'>
-      <h3>{{ site.FormSubmissionFail[page.lang]}}</h3>
+    <div id="prbotSubmitAlertFail" class="alert alert-danger" style="display: none">
+      <b>{{ site.FormSubmissionFail[page.lang]}}</b>
     </div>
-    <div id="prbotSubmitAlertSuccess" class="alert alert-success" style='display: none'>
-      <h3>{{ site.FormSubmissionSuccess[page.lang]}}</h3>
+    <div id="prbotSubmitAlertSuccess" class="alert alert-success" style="display: none">
+      <b3>{{ site.FormSubmissionSuccess[page.lang]}}</b>
     </div>
   </div>
 

--- a/_includes/codeForm.html
+++ b/_includes/codeForm.html
@@ -247,6 +247,15 @@
       <label for="versionProject">{{ site.VersionName[page.lang] }}</label>
       <input class="form-control" id="versionProject" name="versionProject" type="text" />
     </div>
-    <button id="prbotSubmit" type="button" class="btn btn-default">Submit</button>
+  
+  <button id="prbotSubmit" type="button" class="btn btn-primary">Submit</button>
+
+  <h3 id="prbotSubmitAlertInProgress" class="alert alert-warning" style='display: none'>
+    <p>{{ site.FormSubmissionInProgress[page.lang]}}</p>
+  </h3>
+
+  <h3 id="prbotSubmitAlertFail" class="alert alert-danger" style='display: none'>
+    <p>{{ site.FormSubmissionFail[page.lang]}}</p>
+  </h3>
   </form>
   </div>

--- a/_includes/codeForm.html
+++ b/_includes/codeForm.html
@@ -251,15 +251,17 @@
   <button id="prbotSubmit" type="button" class="btn btn-primary">Submit</button>
   <button id="codeFormReset" type="reset" class="btn btn-default">Reset</button>
 
-  <h3 id="prbotSubmitAlertInProgress" class="alert alert-warning" style='display: none'>
-    <p>{{ site.FormSubmissionInProgress[page.lang]}}</p>
-  </h3>
-  <h3 id="prbotSubmitAlertFail" class="alert alert-danger" style='display: none'>
-    <p>{{ site.FormSubmissionFail[page.lang]}}</p>
-  </h3>
-  <h3 id="prbotSubmitAlertSuccess" class="alert alert-success" style='display: none'>
-    <p>{{ site.FormSubmissionSuccess[page.lang]}}</p>
-  </h3>
+  <div style='margin-top: 10px'>
+    <div id="prbotSubmitAlertInProgress" class="alert alert-warning" style='display: none'>
+      <h3>{{ site.FormSubmissionInProgress[page.lang]}}</h3>
+    </div>
+    <div id="prbotSubmitAlertFail" class="alert alert-danger" style='display: none'>
+      <h3>{{ site.FormSubmissionFail[page.lang]}}</h3>
+    </div>
+    <div id="prbotSubmitAlertSuccess" class="alert alert-success" style='display: none'>
+      <h3>{{ site.FormSubmissionSuccess[page.lang]}}</h3>
+    </div>
+  </div>
 
   </form>
   </div>

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -9,7 +9,55 @@ function getSelectedOrgType() {
     .toLowerCase();
 }
 
+/**
+ * Validates the required fields in the codeForm
+ * @returns {Boolean} true/false if the form is valid/invalid
+ */
+function validateRequired() {
+  let form = document.getElementById('validation')
+  let elements = form.elements
+  let validator = $('#validation').validate()
+  let isValid = true
+  for (let i = 0; i < elements.length; i++) {
+    let currentElement = elements[i]
+    if (currentElement.required) {
+      if (!validator.element('#' + currentElement.id)) {
+        isValid = false
+      }
+    }
+  }
+  if (!isValid) {
+    window.scrollTo(0, 0)
+  }
+  return isValid
+}
+
+const ALERT_IN_PROGRESS = 0;
+const ALERT_FAIL = 1;
+const ALERT_OFF = 2;
+
+function toggleAlert(option) {
+  let alertInProgress = document.getElementById('prbotSubmitAlertInProgress')
+  let alertFail = document.getElementById('prbotSubmitAlertFail')
+  if (option == ALERT_IN_PROGRESS) {
+    alertInProgress.style.display = 'block'
+  } else if (option == ALERT_FAIL) {
+    alertFail.style.display = 'block'
+  } else if (option == ALERT_OFF) {
+    alertInProgress.style.display = 'none'
+    alertFail.style.display = 'none'
+  } else {
+    console.log("Invalid option")
+  }
+}
+
 $('#prbotSubmit').click(function() {
+  if (validateRequired()) {
+    console.log("Form input is good")
+    toggleAlert(ALERT_IN_PROGRESS)
+  } else {
+    console.log("Bad form input")
+  }
   let content =
     '' +
     `releases:

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -51,13 +51,7 @@ function toggleAlert(option) {
   }
 }
 
-$('#prbotSubmit').click(function() {
-  if (validateRequired()) {
-    console.log("Form input is good")
-    toggleAlert(ALERT_IN_PROGRESS)
-  } else {
-    console.log("Bad form input")
-  }
+function submitForm() {
   let content =
     '' +
     `releases:
@@ -172,4 +166,14 @@ ${[...document.querySelectorAll('#tagsFR input')]
         throw err;
       }
     });
+}
+
+$('#prbotSubmit').click(function() {
+  if (validateRequired()) {
+    console.log("Form input is good");
+    toggleAlert(ALERT_IN_PROGRESS);
+    submitForm();
+  } else {
+    console.log("Bad form input");
+  }
 });

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -59,8 +59,8 @@ function toggleAlert(option) {
 }
 
 function submitForm() {
-  let submitButton = document.getElementById('prbotSubmit')
-  let resetButton = document.getElementById('codeFormReset')
+  let submitButton = document.getElementById('prbotSubmit');
+  let resetButton = document.getElementById('codeFormReset');
   submitButton.disabled = true;
   resetButton.disabled = true;
   let content =

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -59,6 +59,10 @@ function toggleAlert(option) {
 }
 
 function submitForm() {
+  let submitButton = document.getElementById('prbotSubmit')
+  let resetButton = document.getElementById('codeFormReset')
+  submitButton.disabled = true;
+  resetButton.disabled = true;
   let content =
     '' +
     `releases:
@@ -177,6 +181,8 @@ ${[...document.querySelectorAll('#tagsFR input')]
       if (response.status != 200) {
         toggleAlert(ALERT_OFF);
         toggleAlert(ALERT_FAIL);
+        submitButton.disabled = false;
+        resetButton.disabled = false;
       } else {
         toggleAlert(ALERT_OFF);
         toggleAlert(ALERT_SUCCESS);
@@ -191,7 +197,9 @@ ${[...document.querySelectorAll('#tagsFR input')]
 $('#prbotSubmit').click(function() {
   // Progress only when form input is valid
   if (validateRequired()) {
+    toggleAlert(ALERT_OFF);
     toggleAlert(ALERT_IN_PROGRESS);
+    window.scrollTo(0, document.body.scrollHeight);
     submitForm();
   }
 });

--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -11,43 +11,50 @@ function getSelectedOrgType() {
 
 /**
  * Validates the required fields in the codeForm
- * @returns {Boolean} true/false if the form is valid/invalid
+ * WET uses the JQuery plugin (https://jqueryvalidation.org/) for their form validation
+ * @return {Boolean} true/false if the form is valid/invalid
  */
 function validateRequired() {
-  let form = document.getElementById('validation')
-  let elements = form.elements
-  let validator = $('#validation').validate()
-  let isValid = true
+  let form = document.getElementById('validation');
+  let elements = form.elements;
+  let validator = $('#validation').validate();
+  let isValid = true;
   for (let i = 0; i < elements.length; i++) {
-    let currentElement = elements[i]
+    let currentElement = elements[i];
     if (currentElement.required) {
       if (!validator.element('#' + currentElement.id)) {
-        isValid = false
+        isValid = false;
       }
     }
   }
   if (!isValid) {
-    window.scrollTo(0, 0)
+    // Jump to top of form to see error messages
+    location.href = '#wb-cont';
   }
-  return isValid
+  return isValid;
 }
 
 const ALERT_IN_PROGRESS = 0;
 const ALERT_FAIL = 1;
-const ALERT_OFF = 2;
+const ALERT_SUCCESS = 2;
+const ALERT_OFF = 3;
 
 function toggleAlert(option) {
-  let alertInProgress = document.getElementById('prbotSubmitAlertInProgress')
-  let alertFail = document.getElementById('prbotSubmitAlertFail')
+  let alertInProgress = document.getElementById('prbotSubmitAlertInProgress');
+  let alertFail = document.getElementById('prbotSubmitAlertFail');
+  let alertSuccess = document.getElementById('prbotSubmitAlertSuccess');
   if (option == ALERT_IN_PROGRESS) {
-    alertInProgress.style.display = 'block'
+    alertInProgress.style.display = 'block';
   } else if (option == ALERT_FAIL) {
-    alertFail.style.display = 'block'
+    alertFail.style.display = 'block';
+  } else if (option == ALERT_SUCCESS) {
+    alertSuccess.style.display = 'block';
   } else if (option == ALERT_OFF) {
-    alertInProgress.style.display = 'none'
-    alertFail.style.display = 'none'
+    alertInProgress.style.display = 'none';
+    alertFail.style.display = 'none';
+    alertSuccess.style.display = 'none';
   } else {
-    console.log("Invalid option")
+    console.log('Invalid alert option');
   }
 }
 
@@ -165,15 +172,26 @@ ${[...document.querySelectorAll('#tagsFR input')]
       } else {
         throw err;
       }
+    })
+    .then(response => {
+      if (response.status != 200) {
+        toggleAlert(ALERT_OFF);
+        toggleAlert(ALERT_FAIL);
+      } else {
+        toggleAlert(ALERT_OFF);
+        toggleAlert(ALERT_SUCCESS);
+        // Redirect to home page
+        setTimeout(function() {
+          window.location.href = './index.html';
+        }, 2000);
+      }
     });
 }
 
 $('#prbotSubmit').click(function() {
+  // Progress only when form input is valid
   if (validateRequired()) {
-    console.log("Form input is good");
     toggleAlert(ALERT_IN_PROGRESS);
     submitForm();
-  } else {
-    console.log("Bad form input");
   }
 });


### PR DESCRIPTION
PR for #167 

Displays a [WET styled alert](https://wet-boew.github.io/wet-boew-styleguide/design/alerts-en.html) when the user submits a form. The alert notifies the user of the progress of the submission (*In progress*, *Success*, or *Failed*). Upon a successful submission (PR was created), the user is redirected to the home page.

**Note**
A reset button was also added for the form, however, it seems that the reset button does not clear the tags fields. I will open another issue for this.