### PR TITLE
Minor error in form submit validation rule

### DIFF
--- a/_data/forms/config-oss.yml
+++ b/_data/forms/config-oss.yml
@@ -23,11 +23,9 @@ formGroups:
   - widget: string-i18n
     title: description
     prepend: use
-    rule: alphanum-space
   - widget: string-i18n
     title: name
     prepend: use
-    rule: alphanum-space
   - preset: relatedCode
   - preset: status
   - preset: empty


### PR DESCRIPTION
Fixed error that stopped the form from submitting when description had a dot (.)