### PR TITLE
Removed filling metadatalastupdated field when pulling data

### DIFF
--- a/assets/js/src/codeForm.js
+++ b/assets/js/src/codeForm.js
@@ -501,7 +501,7 @@ function addValueToFields(obj) {
   if (obj.contact.phone) $('#contactphone').val(obj.contact.phone);
 
   $('#datecreated').val(obj.date.created);
-  $('#datelastModified').val(obj.date.metadataLastUpdated);
+  $('#datelastModified').val(obj.date.datelastModified);
 
   $('#enlicensesURL').val(obj.licenses[0].URL.en);
   $('#frlicensesURL').val(obj.licenses[0].URL.fr);

--- a/assets/js/src/ossForm.js
+++ b/assets/js/src/ossForm.js
@@ -479,9 +479,6 @@ function addValueToFieldsAdmin(obj) {
     $('#contactname').val(obj['uses'][0]['contact']['name']);
 
   $('#datestarted').val(obj['uses'][0]['date']['started']);
-  $('#datemetadataLastUpdated').val(
-    obj['uses'][0]['date']['metadataLastUpdated']
-  );
   $('#useenname').val(obj['uses'][0]['name']['en']);
   $('#usefrname').val(obj['uses'][0]['name']['fr']);
   $('#useendescription').val(obj['uses'][0]['description']['en']);


### PR DESCRIPTION
There was errors regarding the metadata last updated field when fetching data using the dropdown select
- In the code form, the datelastmodified field pulled the data from metadataLastUpdated instead of the datalastmodified data.
- In the oss Form, the metadatalastmodified field was trying to get updated, but this isn't its required behaviour since it's a fixed value to today's date and shouldn't change
- The other forms were already following correct behaviour of not updating the metadata field.

**Edit**: Added info in third bullet point about other forms