### PR TITLE
Custom validation UNIQ new admin code & error handling

### DIFF
--- a/_data/forms/rules.yml
+++ b/_data/forms/rules.yml
@@ -3,3 +3,4 @@ names: data-rule-names-en-fr
 phone: data-rule-custom-phone
 dateISO: data-rule-dateISO
 alphanum-space: data-rule-alphanum-space-en-fr
+unique-newadmincode: data-rule-unique-newadmincode

--- a/_includes/form/components/input-group.html
+++ b/_includes/form/components/input-group.html
@@ -2,5 +2,10 @@
   {%- if include.required == nil or include.required %} required="required"{% endif -%}
   {%- if include.value %} value="{{ include.value }}"{% endif -%}
   {%- if include.readonly %} readonly="readonly"{% endif -%}
-  {%- if include.rule %} {{ site.data.forms.rules[include.rule] }}="true"{% endif -%}
+  {%- if include.rule -%}
+    {%- assign rules = include.rule | split: ',' -%}
+    {%- for rule in rules -%}
+      {{ site.data.forms.rules[rule] }}="true"
+    {%- endfor -%}
+  {%- endif -%}
   {%- if include.style %} style="{{ include.style }}"{% endif -%} />

--- a/_includes/form/components/input-group.html
+++ b/_includes/form/components/input-group.html
@@ -4,8 +4,6 @@
   {%- if include.readonly %} readonly="readonly"{% endif -%}
   {%- if include.rule -%}
     {%- assign rules = include.rule | split: ',' -%}
-    {%- for rule in rules -%}
-      {{ site.data.forms.rules[rule] }}="true"
-    {%- endfor -%}
+    {%- for rule in rules %} {{ site.data.forms.rules[rule] }}="true"{%- endfor -%}
   {%- endif -%}
-  {%- if include.style %} style="{{ include.style }}"{% endif -%} />
+  {%- if include.style %} style="{{ include.style }}"{% endif %} />

--- a/_includes/form/components/input-i18n-group.html
+++ b/_includes/form/components/input-i18n-group.html
@@ -2,5 +2,10 @@
   {%- if include.required == nil or include.required %} required="required"{% endif -%}
   {%- if include.value %} value="{{ include.value }}"{% endif -%}
   {%- if include.readonly %} readonly="readonly"{% endif -%}
-  {%- if include.rule %} {{ site.data.forms.rules[include.rule] }}="true"{% endif -%}
+  {%- if include.rule -%}
+    {%- assign rules = include.rule | split: ',' -%}
+    {%- for rule in rules -%}
+      {{ site.data.forms.rules[rule] }}="true"
+    {%- endfor -%}
+  {%- endif -%}
   {%- if include.style %} style="{{ include.style }}"{% endif -%} />

--- a/_includes/form/components/input-i18n-group.html
+++ b/_includes/form/components/input-i18n-group.html
@@ -4,8 +4,6 @@
   {%- if include.readonly %} readonly="readonly"{% endif -%}
   {%- if include.rule -%}
     {%- assign rules = include.rule | split: ',' -%}
-    {%- for rule in rules -%}
-      {{ site.data.forms.rules[rule] }}="true"
-    {%- endfor -%}
+    {%- for rule in rules %} {{ site.data.forms.rules[rule] }}="true"{%- endfor -%}
   {%- endif -%}
-  {%- if include.style %} style="{{ include.style }}"{% endif -%} />
+  {%- if include.style %} style="{{ include.style }}"{% endif %} />

--- a/_includes/form/components/input-i18n.html
+++ b/_includes/form/components/input-i18n.html
@@ -2,5 +2,10 @@
   {%- if include.required == nil or include.required %} required="required"{% endif -%}
   {%- if include.value %} value="{{ include.value }}"{% endif -%}
   {%- if include.readonly %} readonly="readonly"{% endif -%}
-  {%- if include.rule %} {{ site.data.forms.rules[include.rule] }}="true"{% endif -%}
+  {%- if include.rule -%}
+    {%- assign rules = include.rule | split: ',' -%}
+    {%- for rule in rules -%}
+      {{ site.data.forms.rules[rule] }}="true"
+    {%- endfor -%}
+  {%- endif -%}
   {%- if include.style %} style="{{ include.style }}"{% endif -%} />

--- a/_includes/form/components/input-i18n.html
+++ b/_includes/form/components/input-i18n.html
@@ -4,8 +4,6 @@
   {%- if include.readonly %} readonly="readonly"{% endif -%}
   {%- if include.rule -%}
     {%- assign rules = include.rule | split: ',' -%}
-    {%- for rule in rules -%}
-      {{ site.data.forms.rules[rule] }}="true"
-    {%- endfor -%}
+    {%- for rule in rules %} {{ site.data.forms.rules[rule] }}="true"{%- endfor -%}
   {%- endif -%}
-  {%- if include.style %} style="{{ include.style }}"{% endif -%} />
+  {%- if include.style %} style="{{ include.style }}"{% endif %} />

--- a/_includes/form/components/input.html
+++ b/_includes/form/components/input.html
@@ -2,5 +2,10 @@
   {%- if include.required == nil or include.required %} required="required"{% endif -%}
   {%- if include.value %} value="{{ include.value }}"{% endif -%}
   {%- if include.readonly %} readonly="readonly"{% endif -%}
-  {%- if include.rule %} {{ site.data.forms.rules[include.rule] }}="true"{% endif -%}
+  {%- if include.rule -%}
+    {%- assign rules = include.rule | split: ',' -%}
+    {%- for rule in rules -%}
+      {{ site.data.forms.rules[rule] }}="true"
+    {%- endfor -%}
+  {%- endif -%}
   {%- if include.style %} style="{{ include.style }}"{% endif -%} />

--- a/_includes/form/components/input.html
+++ b/_includes/form/components/input.html
@@ -4,8 +4,6 @@
   {%- if include.readonly %} readonly="readonly"{% endif -%}
   {%- if include.rule -%}
     {%- assign rules = include.rule | split: ',' -%}
-    {%- for rule in rules -%}
-      {{ site.data.forms.rules[rule] }}="true"
-    {%- endfor -%}
+    {%- for rule in rules %} {{ site.data.forms.rules[rule] }}="true"{%- endfor -%}
   {%- endif -%}
-  {%- if include.style %} style="{{ include.style }}"{% endif -%} />
+  {%- if include.style %} style="{{ include.style }}"{% endif %} />

--- a/_includes/form/components/label-group.html
+++ b/_includes/form/components/label-group.html
@@ -1,5 +1,5 @@
 {%- capture path -%}{{ include.prepend }}{{ include.title }}{%- endcapture -%}
 <label for="{{ path }}{{ include.group }}"
   {%- if include.required == nil or include.required %} class="required"{% endif -%}
->{{ site.data.i18n.form[include.id][path].labels[include.group][page.lang] }}
+><span class="field-name">{{ site.data.i18n.form[include.id][path].labels[include.group][page.lang] }}</span>
 {%- if include.required == nil or include.required %} <strong class="required">({{ site.data.i18n.form.required[page.lang] }})</strong>{% endif %}</label>

--- a/_includes/form/components/label-i18n-group.html
+++ b/_includes/form/components/label-i18n-group.html
@@ -1,5 +1,5 @@
 {%- capture path -%}{{ include.prepend }}{{ include.title }}{%- endcapture -%}
 <label for="{{ include.prepend }}{{ include.lang }}{{ include.title }}{{ include.group }}"
   {%- if include.required == nil or include.required %} class="required"{% endif -%}
->{{ site.data.i18n.form[include.id][path].labels[include.group][include.lang][page.lang] }}
+><span class="field-name">{{ site.data.i18n.form[include.id][path].labels[include.group][include.lang][page.lang] }}</span>
 {%- if include.required == nil or include.required %} <strong class="required">({{ site.data.i18n.form.required[page.lang] }})</strong>{% endif %}</label>

--- a/_includes/form/components/label-i18n.html
+++ b/_includes/form/components/label-i18n.html
@@ -1,4 +1,4 @@
 <label for="{{ include.prepend }}{{ include.lang }}{{ include.title }}"
   {%- if include.required == nil or include.required %} class="required"{% endif -%}
->{{ site.data.i18n.form[include.id][path].label[include.lang][page.lang] }}
+><span class="field-name">{{ site.data.i18n.form[include.id][path].label[include.lang][page.lang] }}</span>
 {%- if include.required == nil or include.required %} <strong class="required">({{ site.data.i18n.form.required[page.lang] }})</strong>{% endif %}</label>

--- a/_includes/form/components/label.html
+++ b/_includes/form/components/label.html
@@ -1,5 +1,5 @@
 {%- capture path -%}{{ include.prepend }}{{ include.title }}{%- endcapture -%}
 <label for="{{ path }}"
   {%- if include.required == nil or include.required %} class="required"{% endif -%}
->{{ site.data.i18n.form[include.id][path].label[page.lang] }}
+><span class="field-name">{{ site.data.i18n.form[include.id][path].label[page.lang] }}</span>
 {%- if include.required == nil or include.required %} <strong class="required">({{ site.data.i18n.form.required[page.lang] }})</strong>{% endif %}</label>

--- a/_includes/form/presets/newAdmin.html
+++ b/_includes/form/presets/newAdmin.html
@@ -6,7 +6,7 @@
 <button id="removeNewAdminButton" style = "position: absolute; top: 10px; right: 10px;" class="btn btn-default remove" type="button"><i class="glyphicon glyphicon-remove"></i></button>
 {%- endif %}
 {% include form/presets/orgLevel.html id=include.id %}
-{% include form/widgets/string.html id=id title="newAdminCode" rule="names" %}
+{% include form/widgets/string.html id=id title="newAdminCode" rule="unique-newadmincode" %}
 {% include form/presets/provinceSelect.html id=include.id %}
 {% include form/widgets/string-i18n.html id=id title="newAdminName" rule="alphanum-space" -%}
 </div>

--- a/_includes/form/presets/newAdmin.html
+++ b/_includes/form/presets/newAdmin.html
@@ -6,7 +6,7 @@
 <button id="removeNewAdminButton" style = "position: absolute; top: 10px; right: 10px;" class="btn btn-default remove" type="button"><i class="glyphicon glyphicon-remove"></i></button>
 {%- endif %}
 {% include form/presets/orgLevel.html id=include.id %}
-{% include form/widgets/string.html id=id title="newAdminCode" rule="unique-newadmincode" %}
+{% include form/widgets/string.html id=id title="newAdminCode" rule="unique-newadmincode,names" %}
 {% include form/presets/provinceSelect.html id=include.id %}
 {% include form/widgets/string-i18n.html id=id title="newAdminName" rule="alphanum-space" -%}
 </div>

--- a/assets/js/src/adminForm.js
+++ b/assets/js/src/adminForm.js
@@ -62,7 +62,9 @@ function resetNewAdminForm() {
 
 function getAdminObject() {
   let adminObject = {
-    code: $('#newAdminCode').val(),
+    code: $('#newAdminCode')
+      .val()
+      .toLowerCase(),
     provinceCode: $('#provinceSelect').val(),
     name: {
       en: $('#ennewAdminName').val(),

--- a/assets/js/src/custom-form-validation.js
+++ b/assets/js/src/custom-form-validation.js
@@ -19,6 +19,10 @@ const phoneError = {
   en: 'Please enter a valid phone number.',
   fr: 'Veuillez fournir un numéro de téléphone valide.'
 };
+const uniqNewAdminError = {
+  en: 'This admin code already exists.',
+  fr: "Ce code d'administration existe déjà."
+};
 
 $(document).on('wb-ready.wb', function() {
   let lang = document.documentElement.lang;
@@ -111,6 +115,24 @@ $(document).on('wb-ready.wb', function() {
         return true;
       },
       jQuery.validator.format(phoneError[lang])
+    );
+
+    /**
+     * Custom unique value. Usage: new admin code must be unique
+     */
+    jQuery.validator.addMethod(
+      'unique-newadmincode',
+      function(value) {
+        if (value) {
+          let valid = true;
+          $('#adminCode option').each(function(i, option) {
+            if (value.toLowerCase() === $(option).val()) valid = false;
+          });
+          return valid;
+        }
+        return true;
+      },
+      jQuery.validator.format(uniqNewAdminError[lang])
     );
   }
 });


### PR DESCRIPTION
From #615 

**Major:**
 - Added validation to new admin code so it wouldn't accept an already existing one

**Minor:**
 - Wrapped the labels in a span.field-name so WET validation would throw a more meaningful error (using the name of the field in the error description)