### PR TITLE
Changed travis build: oraclejdk8 --> openjdk12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
 - 2.6.0
 
 jdk:
-- oraclejdk8
+- openjdk12
 
 install:
 - bundle install


### PR DESCRIPTION
From what I gathered in #621 and from the internet, and from the fact that we're big on open source, I suggest we use OpenJDK version 12. It's the latest stable release and it's open source.

Just from an update standpoint, with what I read on an article (https://www.baeldung.com/oracle-jdk-vs-openjdk)
 - openJDKs are a little bit more short lived
   - the releases are supported for 6 months until the new version is released
   - openjdk12 was released march 19, 2019
 - The LTS (long-term-support) releases of oracleJDK are supported for 3 years
    - which would be oracleJDK11 at this point (released in 2018)

But travis' accepted version are from 9 to 14 so it should last enough time before we have to worry about it.