### PR TITLE
Added infobulle back to label-title

### DIFF
--- a/_includes/form/components/label.html
+++ b/_includes/form/components/label.html
@@ -1,4 +1,7 @@
 {%- capture path -%}{{ include.param.prepend }}{{ include.title }}{%- endcapture -%}
-<label for="{{ path }}"{%- if include.param.required == nil or include.param.required %} class="required"{% endif -%}>
-<span class="field-name h2">{{ site.data.i18n.form[include.id][path].label[page.lang] }}</span>
+<label for="{{ path }}" class="h2{%- if include.param.required == nil or include.param.required %} required{% endif -%}">
+  <span>
+    <span class="field-name">{{ site.data.i18n.form[include.id][path].label[page.lang] }}</span>
+    <span data-toggle="tooltip" data-placement="top" title="{{ site.data.i18n.form[include.id][path].infobulle[page.lang] }}" class="glyphicon glyphicon-question-sign small" aria-hidden="true"></span>
+  </span>
 </label>


### PR DESCRIPTION
There's only an issue with this change, it's that because the label has the same style as a title, the error label also has that style, making it a little too big.
![error-msg-large](https://user-images.githubusercontent.com/50632796/63711343-3458b380-c809-11e9-905e-43867be2a18a.png)
