### PR TITLE
Changes so error wouldn't appear in console

### DIFF
--- a/assets/js/src/adminForm.js
+++ b/assets/js/src/adminForm.js
@@ -99,6 +99,8 @@ function getSelectedOrgType() {
 }
 
 function getOrgLevel(result, admin) {
+  if (result == null) return undefined;
+
   let federal = result.federal[admin];
   let provincial = result.provincial[admin];
   let municipal = result.municipal[admin];


### PR DESCRIPTION
In the case of partnership, since there's no data yet, the json file is empty and when trying to call the getOrgLevel, it was trying to access data of a null object, which was throwing an error in the console. I added a bit of code so it wouldn't show up in the console.