### PR TITLE
Update LESK spdx and license URL

### DIFF
--- a/_data/software/lesk.yml
+++ b/_data/software/lesk.yml
@@ -16,9 +16,9 @@ homepageURL:
   fr: 'https://lesk.it'
 licences:
   - URL:
-      en: 'http://lesk.it/license.html'
-      fr: 'http://lesk.it/license.html'
-    spdxID: GPL-3.0
+      en: 'https://github.com/leskhq/Laravel-Enterprise-Starter-Kit/blob/master/LICENSE.md'
+      fr: 'https://github.com/leskhq/Laravel-Enterprise-Starter-Kit/blob/master/LICENSE.md'
+    spdxID: GPL-3.0-only
   - URL:
       en: 'http://lesk.it/license.html'
       fr: 'http://lesk.it/license.html'

--- a/_data/software/lesk.yml
+++ b/_data/software/lesk.yml
@@ -20,8 +20,8 @@ licences:
       fr: 'https://github.com/leskhq/Laravel-Enterprise-Starter-Kit/blob/master/LICENSE.md'
     spdxID: GPL-3.0-only
   - URL:
-      en: 'http://lesk.it/license.html'
-      fr: 'http://lesk.it/license.html'
+      en: 'https://github.com/leskhq/Laravel-Enterprise-Starter-Kit/blob/master/LICENSE.md'
+      fr: 'https://github.com/leskhq/Laravel-Enterprise-Starter-Kit/blob/master/LICENSE.md'
     spdxID: Apache-2.0
 name:
   en: LESK


### PR DESCRIPTION
Currently, the domain is parked so the licences URL doesn't work.
Confirmed the original idea from the raw file https://github.com/leskhq/leskhq.github.io/blob/master/license.html