### PR TITLE
Update YAML schemas for Yamale 2.0 - create requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ jdk:
 
 install:
 - bundle install
-- pip install --user html5validator
-- pip install --user yamale==1.10.1
+- pip install --user -r requirements.txt
 - npm install
-- pip install --user yamllint
 
 script:
 - bundle exec jekyll build
@@ -23,6 +21,5 @@ script:
 - yamale -s schemaPartnership.yaml _data/partnership
 - npm test
 - yamllint -d configYamlLint.yml _data
-
 
 sudo: false

--- a/_data/code/federal/tbs-sct.yml
+++ b/_data/code/federal/tbs-sct.yml
@@ -41,8 +41,10 @@ releases:
     relatedCode:
       - URL:
           en: 'https://github.com/Elgg/Elgg'
+          fr: 'https://github.com/Elgg/Elgg'
         name:
           en: Elgg
+          fr: Elgg
     status: Maintained
   - contact:
       email: cds-snc@tbs-sct.gc.ca

--- a/_data/schemaAdmin.yaml
+++ b/_data/schemaAdmin.yaml
@@ -1,6 +1,8 @@
 ---
 - code: str()
   provinceCode: enum('ab', 'bc', 'mb', 'nb', 'nl', 'nt', 'ns', 'nu', 'on', 'pe', 'qc', 'sk', 'yt', required=False)
-  name:
-    en: str()
-    fr: str()
+  name: include('lang')
+---
+lang:
+  en: str()
+  fr: str()

--- a/_data/schemaAdmin.yaml
+++ b/_data/schemaAdmin.yaml
@@ -1,8 +1,11 @@
 ---
-- code: str()
-  provinceCode: enum('ab', 'bc', 'mb', 'nb', 'nl', 'nt', 'ns', 'nu', 'on', 'pe', 'qc', 'sk', 'yt', required=False)
-  name: include('lang', strict=True)
+list(include('admin', strict=True))
 ---
+admin:
+  code: str()
+  provinceCode: enum('ab', 'bc', 'mb', 'nb', 'nl', 'nt', 'ns', 'nu', 'on', 'pe', 'qc', 'sk', 'yt', required=False)
+  name: include('lang')
+
 lang:
   en: str()
   fr: str()

--- a/_data/schemaAdmin.yaml
+++ b/_data/schemaAdmin.yaml
@@ -1,7 +1,7 @@
 ---
 - code: str()
   provinceCode: enum('ab', 'bc', 'mb', 'nb', 'nl', 'nt', 'ns', 'nu', 'on', 'pe', 'qc', 'sk', 'yt', required=False)
-  name: include('lang')
+  name: include('lang', strict=True)
 ---
 lang:
   en: str()

--- a/_data/schemaCode.yaml
+++ b/_data/schemaCode.yaml
@@ -12,9 +12,7 @@ releases:
       whatItDoes:
         en: str()
         fr: str()
-      howItWorks:
-        en: str(required=False)
-        fr: str(required=False)
+      howItWorks: include('lang', required=False)
     category: str()
     name:
       en: str()
@@ -32,26 +30,23 @@ releases:
         - str()
       fr:
         - str()
-    downloadURL:
-      en: str(required=False)
-      fr: str(required=False)
-    homepageURL:
-      en: str(required=False)
-      fr: str(required=False)
-    languages:
-      - str(required=False)
-    partners:
-      - adminCode: str(required=False)
-        email: str(required=False)
-        name: str(required=False)
-    relatedCode:
-      - URL:
-          en: str(required=False)
-          fr: str(required=False)
-        name:
-          en: str(required=False)
-          fr: str(required=False)
+    downloadURL: include('lang', required=False)
+    homepageURL: include('lang', required=False)
+    languages: list(str(required=False), required=False)
+    partners: list(include('partner'), required=False)
+    relatedCode: list(include('related'), required=False)
     status: enum('Alpha', 'Beta', 'Maintained', 'Deprecated', 'Retired', required=False)
-    team:
-      en: str(required=False)
-      fr: str(required=False)
+    team: include('lang', required=False)
+---
+partner:
+  adminCode: str(required=False)
+  email: str(required=False)
+  name: str(required=False)
+
+related:
+  URL: include('lang', required=False)
+  name: include('lang', required=False)
+
+lang:
+  en: str(required=False)
+  fr: str(required=False)

--- a/_data/schemaCode.yaml
+++ b/_data/schemaCode.yaml
@@ -1,33 +1,37 @@
 ---
 schemaVersion: str()
 adminCode: str()
-releases:
-  - contact:
-      email: str()
-      name: str(required=False)
-    date:
-      created: str()
-      metadataLastUpdated: str()
-    description:
-      whatItDoes: include('lang')
-      howItWorks: include('lang', required=False)
-    category: str()
-    name: include('lang')
-    licences:
-      - URL: include('lang')
-        spdxID: str()
-    repositoryURL: include('lang')
-    tags:
-      en: list(str())
-      fr: list(str())
-    downloadURL: include('lang', required=False)
-    homepageURL: include('lang', required=False)
-    languages: list(str(), required=False)
-    partners: list(include('partner'), required=False)
-    relatedCode: list(include('related'), required=False)
-    status: enum('Alpha', 'Beta', 'Maintained', 'Deprecated', 'Retired', required=False)
-    team: include('lang', required=False)
+releases: list(include('release', strict=True))
 ---
+release:
+  contact:
+    email: str()
+    name: str(required=False)
+  date:
+    created: str()
+    metadataLastUpdated: str()
+  description:
+    whatItDoes: include('lang')
+    howItWorks: include('lang', required=False)
+  category: str()
+  name: include('lang')
+  licences: list(include('licence'))
+  repositoryURL: include('lang')
+  tags:
+    en: list(str())
+    fr: list(str())
+  downloadURL: include('lang', required=False)
+  homepageURL: include('lang', required=False)
+  languages: list(str(), required=False)
+  partners: list(include('partner'), required=False)
+  relatedCode: list(include('related'), required=False)
+  status: enum('Alpha', 'Beta', 'Maintained', 'Deprecated', 'Retired', required=False)
+  team: include('lang', required=False)
+
+licence:
+  URL: include('lang')
+  spdxID: str()
+
 partner:
   adminCode: str()
   email: str()

--- a/_data/schemaCode.yaml
+++ b/_data/schemaCode.yaml
@@ -1,8 +1,11 @@
 ---
-schemaVersion: str()
-adminCode: str()
-releases: list(include('release', strict=True))
+include('code', strict=True)
 ---
+code:
+  schemaVersion: str()
+  adminCode: str()
+  releases: list(include('release'))
+
 release:
   contact:
     email: str()

--- a/_data/schemaCode.yaml
+++ b/_data/schemaCode.yaml
@@ -9,44 +9,34 @@ releases:
       created: str()
       metadataLastUpdated: str()
     description:
-      whatItDoes:
-        en: str()
-        fr: str()
+      whatItDoes: include('lang')
       howItWorks: include('lang', required=False)
     category: str()
-    name:
-      en: str()
-      fr: str()
+    name: include('lang')
     licences:
-      - URL:
-          en: str()
-          fr: str()
+      - URL: include('lang')
         spdxID: str()
-    repositoryURL:
-      en: str()
-      fr: str()
+    repositoryURL: include('lang')
     tags:
-      en:
-        - str()
-      fr:
-        - str()
+      en: list(str())
+      fr: list(str())
     downloadURL: include('lang', required=False)
     homepageURL: include('lang', required=False)
-    languages: list(str(required=False), required=False)
+    languages: list(str(), required=False)
     partners: list(include('partner'), required=False)
     relatedCode: list(include('related'), required=False)
     status: enum('Alpha', 'Beta', 'Maintained', 'Deprecated', 'Retired', required=False)
     team: include('lang', required=False)
 ---
 partner:
-  adminCode: str(required=False)
-  email: str(required=False)
-  name: str(required=False)
+  adminCode: str()
+  email: str()
+  name: str()
 
 related:
-  URL: include('lang', required=False)
-  name: include('lang', required=False)
+  URL: include('lang')
+  name: include('lang')
 
 lang:
-  en: str(required=False)
-  fr: str(required=False)
+  en: str()
+  fr: str()

--- a/_data/schemaPartnership.yaml
+++ b/_data/schemaPartnership.yaml
@@ -15,21 +15,23 @@ projects:
       whatItDoes:
         en: str()
         fr: str()
-      howItWorks:
-        en: str(required=False)
-        fr: str(required=False)
+      howItWorks: include('lang', required=False)
     name:
       en: str()
       fr: str()
-    partners:
-      - adminCode: str(required=False)
-        email: str(required=False)
-        name: str(required=False)
+    partners: list(include('partner'), required=False)
     tags:
       en:
         - str(required=False)
       fr:
         - str(required=False)
-    team:
-      en: str(required=False)
-      fr: str(required=False)
+    team: include('lang', required=False)
+---
+partner:
+  adminCode: str(required=False)
+  email: str(required=False)
+  name: str(required=False)
+
+lang:
+  en: str(required=False)
+  fr: str(required=False)

--- a/_data/schemaPartnership.yaml
+++ b/_data/schemaPartnership.yaml
@@ -1,8 +1,11 @@
 ---
-schemaVersion: str()
-adminCode: str()
-projects: list(include('project', strict=True))
+include('partnership', strict=True)
 ---
+partnership:
+  schemaVersion: str()
+  adminCode: str()
+  projects: list(include('project'))
+
 project:
   contact:
     email: str()

--- a/_data/schemaPartnership.yaml
+++ b/_data/schemaPartnership.yaml
@@ -1,26 +1,28 @@
 ---
 schemaVersion: str()
 adminCode: str()
-projects:
-  - contact:
-      email: str()
-      name: str(required=False)
-      phone: str(required=False)
-    category: str()
-    date:
-      closed: str()
-      started: str()
-      metadataLastUpdated: str()
-    description:
-      whatItDoes: include('lang')
-      howItWorks: include('lang', required=False)
-    name: include('lang')
-    partners: list(include('partner'), required=False)
-    tags:
-      en: list(str())
-      fr: list(str())
-    team: include('lang', required=False)
+projects: list(include('project', strict=True))
 ---
+project:
+  contact:
+    email: str()
+    name: str(required=False)
+    phone: str(required=False)
+  category: str()
+  date:
+    closed: str()
+    started: str()
+    metadataLastUpdated: str()
+  description:
+    whatItDoes: include('lang')
+    howItWorks: include('lang', required=False)
+  name: include('lang')
+  partners: list(include('partner'), required=False)
+  tags:
+    en: list(str())
+    fr: list(str())
+  team: include('lang', required=False)
+
 partner:
   adminCode: str()
   email: str()

--- a/_data/schemaPartnership.yaml
+++ b/_data/schemaPartnership.yaml
@@ -12,26 +12,20 @@ projects:
       started: str()
       metadataLastUpdated: str()
     description:
-      whatItDoes:
-        en: str()
-        fr: str()
+      whatItDoes: include('lang')
       howItWorks: include('lang', required=False)
-    name:
-      en: str()
-      fr: str()
+    name: include('lang')
     partners: list(include('partner'), required=False)
     tags:
-      en:
-        - str(required=False)
-      fr:
-        - str(required=False)
+      en: list(str())
+      fr: list(str())
     team: include('lang', required=False)
 ---
 partner:
-  adminCode: str(required=False)
-  email: str(required=False)
-  name: str(required=False)
+  adminCode: str()
+  email: str()
+  name: str()
 
 lang:
-  en: str(required=False)
-  fr: str(required=False)
+  en: str()
+  fr: str()

--- a/_data/schemaSoftware.yaml
+++ b/_data/schemaSoftware.yaml
@@ -1,15 +1,18 @@
 ---
-schemaVersion: str()
-description:
-  whatItDoes: include('lang', strict=True)
-  howItWorks: include('lang', required=False, strict=True)
-category: str()
-homepageURL: include('lang', strict=True)
-licences: list(include('licence', strict=True))
-name: include('lang', strict=True)
-tags: include('tag', strict=True)
-administrations: list(include('administration', strict=True))
+include('software', strict=True)
 ---
+software:
+  schemaVersion: str()
+  description:
+    whatItDoes: include('lang')
+    howItWorks: include('lang', required=False)
+  category: str()
+  homepageURL: include('lang')
+  licences: list(include('licence'))
+  name: include('lang')
+  tags: include('tag')
+  administrations: list(include('administration'))
+
 licence:
   URL: include('lang')
   spdxID: str()

--- a/_data/schemaSoftware.yaml
+++ b/_data/schemaSoftware.yaml
@@ -6,22 +6,14 @@ description:
     fr: str()
   howItWorks: include('lang', required=False)
 category: str()
-homepageURL:
-  en: str()
-  fr: str()
+homepageURL: include('lang')
 licences:
-  - URL:
-      en: str()
-      fr: str()
+  - URL: include('lang')
     spdxID: str()
-name:
-  en: str()
-  fr: str()
+name: include('lang')
 tags:
-  en:
-    - str()
-  fr:
-    - str()
+  en: list(str())
+  fr: list(str())
 administrations:
   - adminCode: str()
     uses:
@@ -34,5 +26,5 @@ administrations:
         team: include('lang', required=False)
 ---
 lang:
-  en: str(required=False)
-  fr: str(required=False)
+  en: str()
+  fr: str()

--- a/_data/schemaSoftware.yaml
+++ b/_data/schemaSoftware.yaml
@@ -1,30 +1,36 @@
 ---
 schemaVersion: str()
 description:
-  whatItDoes:
-    en: str()
-    fr: str()
-  howItWorks: include('lang', required=False)
+  whatItDoes: include('lang', strict=True)
+  howItWorks: include('lang', required=False, strict=True)
 category: str()
-homepageURL: include('lang')
-licences:
-  - URL: include('lang')
-    spdxID: str()
-name: include('lang')
-tags:
+homepageURL: include('lang', strict=True)
+licences: list(include('licence', strict=True))
+name: include('lang', strict=True)
+tags: include('tag', strict=True)
+administrations: list(include('administration', strict=True))
+---
+licence:
+  URL: include('lang')
+  spdxID: str()
+
+tag:
   en: list(str())
   fr: list(str())
-administrations:
-  - adminCode: str()
-    uses:
-      - contact:
-          email: str()
-          name: str(required=False)
-        date:
-          started: str()
-          metadataLastUpdated: str()
-        team: include('lang', required=False)
----
+
+administration:
+  adminCode: str()
+  uses: list(include('use'))
+
+use:
+  contact:
+    email: str()
+    name: str(required=False)
+  date:
+    started: str()
+    metadataLastUpdated: str()
+  team: include('lang', required=False)
+
 lang:
   en: str()
   fr: str()

--- a/_data/schemaSoftware.yaml
+++ b/_data/schemaSoftware.yaml
@@ -4,9 +4,7 @@ description:
   whatItDoes:
     en: str()
     fr: str()
-  howItWorks:
-    en: str(required=False)
-    fr: str(required=False)
+  howItWorks: include('lang', required=False)
 category: str()
 homepageURL:
   en: str()
@@ -33,6 +31,8 @@ administrations:
         date:
           started: str()
           metadataLastUpdated: str()
-        team:
-          en: str(required=False)
-          fr: str(required=False)
+        team: include('lang', required=False)
+---
+lang:
+  en: str(required=False)
+  fr: str(required=False)

--- a/_data/schemaStandard.yaml
+++ b/_data/schemaStandard.yaml
@@ -4,9 +4,7 @@ description:
   whatItDoes:
     en: str()
     fr: str()
-  howItWorks:
-    en: str(required=False)
-    fr: str(required=False)
+  howItWorks: include('lang', required=False)
 name:
   en: str()
   fr: str()
@@ -38,6 +36,8 @@ administrations:
           en: str()
           fr: str()
     status: enum('deprecated', 'mandatory', 'preferred')
-    team:
-      en: str(required=False)
-      fr: str(required=False)
+    team: include('lang', required=False)
+---
+lang:
+  en: str(required=False)
+  fr: str(required=False)

--- a/_data/schemaStandard.yaml
+++ b/_data/schemaStandard.yaml
@@ -1,25 +1,15 @@
 ---
 schemaVersion: str()
 description:
-  whatItDoes:
-    en: str()
-    fr: str()
+  whatItDoes: include('lang')
   howItWorks: include('lang', required=False)
-name:
-  en: str()
-  fr: str()
-specURL:
-  en: str()
-  fr: str()
+name: include('lang')
+specURL: include('lang')
 standardAcronym: str()
-standardOrg:
-  en: str()
-  fr: str()
+standardOrg: include('lang')
 tags:
-  en:
-    - str()
-  fr:
-    - str()
+  en: list(str())
+  fr: list(str())
 administrations:
   - adminCode: str()
     contact:
@@ -29,15 +19,11 @@ administrations:
       created: str()
       metadataLastUpdated: str()
     references:
-      - URL:
-          en: str()
-          fr: str()
-        name:
-          en: str()
-          fr: str()
+      - URL: include('lang')
+        name: include('lang')
     status: enum('deprecated', 'mandatory', 'preferred')
     team: include('lang', required=False)
 ---
 lang:
-  en: str(required=False)
-  fr: str(required=False)
+  en: str()
+  fr: str()

--- a/_data/schemaStandard.yaml
+++ b/_data/schemaStandard.yaml
@@ -1,15 +1,18 @@
 ---
-schemaVersion: str()
-description:
-  whatItDoes: include('lang', strict=True)
-  howItWorks: include('lang', required=False, strict=True)
-name: include('lang', strict=True)
-specURL: include('lang', strict=True)
-standardAcronym: str()
-standardOrg: include('lang', strict=True)
-tags: include('tag', strict=True)
-administrations: list(include('administration', strict=True))
+include('standard', strict=True)
 ---
+standard:
+  schemaVersion: str()
+  description:
+    whatItDoes: include('lang')
+    howItWorks: include('lang', required=False)
+  name: include('lang')
+  specURL: include('lang')
+  standardAcronym: str()
+  standardOrg: include('lang')
+  tags: include('tag')
+  administrations: list(include('administration'))
+
 tag:
   en: list(str())
   fr: list(str())

--- a/_data/schemaStandard.yaml
+++ b/_data/schemaStandard.yaml
@@ -1,29 +1,35 @@
 ---
 schemaVersion: str()
 description:
-  whatItDoes: include('lang')
-  howItWorks: include('lang', required=False)
-name: include('lang')
-specURL: include('lang')
+  whatItDoes: include('lang', strict=True)
+  howItWorks: include('lang', required=False, strict=True)
+name: include('lang', strict=True)
+specURL: include('lang', strict=True)
 standardAcronym: str()
-standardOrg: include('lang')
-tags:
+standardOrg: include('lang', strict=True)
+tags: include('tag', strict=True)
+administrations: list(include('administration', strict=True))
+---
+tag:
   en: list(str())
   fr: list(str())
-administrations:
-  - adminCode: str()
-    contact:
-      email: str()
-      name: str(required=False)
-    date:
-      created: str()
-      metadataLastUpdated: str()
-    references:
-      - URL: include('lang')
-        name: include('lang')
-    status: enum('deprecated', 'mandatory', 'preferred')
-    team: include('lang', required=False)
----
+
+administration:
+  adminCode: str()
+  contact:
+    email: str()
+    name: str(required=False)
+  date:
+    created: str()
+    metadataLastUpdated: str()
+  references: list(include('reference'))
+  status: enum('deprecated', 'mandatory', 'preferred')
+  team: include('lang', required=False)
+
+reference:
+  URL: include('lang')
+  name: include('lang')
+
 lang:
   en: str()
   fr: str()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+html5validator==0.3.1
+yamale==2.0.1
+yamllint==1.18.0


### PR DESCRIPTION
Fixes #702 issue with [Yamale 2.0](https://github.com/23andMe/Yamale/releases/tag/2.0) to validate the data schemas.

> In the 1.x branch, if all the children of a node are optional, then the parent is optional as well. In the 2.x branch, the parent will no longer be optional in this case.

This PR make the parents explicitly optional using includes and lists.

I also created a requirements.txt with version for Python packages used for the build, instead of defining them in the Travis file.

Fixed one actual error in the TBS code file.