### PR TITLE
Use existing form translations for codetable status

### DIFF
--- a/_includes/codeTable.html
+++ b/_includes/codeTable.html
@@ -245,7 +245,8 @@
         </ul>
         {%- endif -%}
         {%- if release.status != nil -%}
-          <p>{{ site.data.i18n.tables.status[page.lang] }}: {{ release.status }}</p>
+          {%- assign status = release.status | downcase -%}
+          <p>{{ site.data.i18n.tables.status[page.lang] }}: {{ site.data.i18n.form.presets.status.options[status][page.lang] }}</p>
         {%- endif -%}
         <p>{{ site.data.i18n.form.code.date.label[page.lang] }}: {{ release.date.created }}</p>
 


### PR DESCRIPTION
This PR updates the code table lightbox to display the correct translation for status of a project.

I reused existing form translations found here
https://github.com/canada-ca/ore-ero/blob/master/_data/i18n/form.yml