### PR TITLE
fix: Get data value for getSelectedOrgType

### DIFF
--- a/assets/js/src/adminForm.js
+++ b/assets/js/src/adminForm.js
@@ -93,8 +93,7 @@ function getSelectedOrgType() {
   if ($('#adminCode').val() != '')
     return $('#adminCode :selected')
       .parent()
-      .attr('label')
-      .toLowerCase();
+      .data('value');
   else return $('#orgLevel').val();
 }
 

--- a/assets/js/src/softwareForm.js
+++ b/assets/js/src/softwareForm.js
@@ -119,8 +119,7 @@ function getSelectedOrgType() {
   if ($('#adminCode').val() != '')
     return $('#adminCode :selected')
       .parent()
-      .attr('label')
-      .toLowerCase();
+      .data('value');
   else return $('#orgLevel').val();
 }
 


### PR DESCRIPTION
Previous version would use French file names when submitting form. This pulls the value off of the "optgroup" instead of the name.

Closes #844 which was an example of this not working from the French form