### PR TITLE
Add "other" License for special cases like SQLLite

### DIFF
--- a/_data/i18n/licences.yml
+++ b/_data/i18n/licences.yml
@@ -182,3 +182,7 @@ Zlib:
 ZPL-2.0:
   name: Zope Public License 2.0
   value: ZPL-2.0
+Non-SPDX-or-Public-Domain:
+  name: Non-SPDX Listed License and Public Domain
+  value: Non-SPDX-or-Public-Domain
+  


### PR DESCRIPTION
Adds a License type for cases like SQLLite where they refuse to License, but declare themselves as Public Domain.