### PR TITLE
Open portals page

### DIFF
--- a/_pages/en/index.html
+++ b/_pages/en/index.html
@@ -115,8 +115,9 @@ permalink: /en/index.html
       </li>
       <li>
         <details open>
-          <summary>Open portals from canadian public administrations</summary>
-          Check the list of <a href="./open-portal.html">open portals from canadian public administrations</a> to find other open portals 
+          <summary>List of open portals from canadian public administrations</summary>
+          Canadian public administrations have created open portals to make accessing their data and information easier for the public.
+          Check the <a href="./open-portal.html">list of open portals from canadian public administrations</a> to find the available open portals.
         </details>
       </li>
     </ul>

--- a/_pages/en/index.html
+++ b/_pages/en/index.html
@@ -113,6 +113,12 @@ permalink: /en/index.html
             Governmental groups across the world have also developed collaborative platforms for sharing open source solutions between public administrations in a country or region. For more information about those platforms, you can check our non-exhaustive <a href="./catalog.html">list of international catalogs for open source solutions</a>.
         </details>
       </li>
+      <li>
+        <details open>
+          <summary>Open portals from canadian public administrations</summary>
+          Check the list of <a href="./open-portal.html">open portals from canadian public administrations</a> to find other open portals 
+        </details>
+      </li>
     </ul>
   </div>
 </div>

--- a/_pages/en/open-portal.html
+++ b/_pages/en/open-portal.html
@@ -7,7 +7,7 @@ permalink: en/open-portal.html
 
 <div class="row profile">
     <div class="col-md-12">
-        <h1 property="name">Open Portals</h1> 
+        <h1 property="name"id="wb-cont">Open Portals</h1> 
     </div>
 
     <div class="row profile">

--- a/_pages/en/open-portal.html
+++ b/_pages/en/open-portal.html
@@ -9,20 +9,53 @@ permalink: en/open-portal.html
     <div class="col-md-12">
         <h1 property="name" id="wb-cont">Open Portals</h1> 
     </div>
-
-    <div class="row profile">
-        <div class="col-md-12"><h3 property="name">Open Government</h3></div>    
-        <p><strong><a href="https://open.canada.ca/en">Open Government</a></strong> aims to have government be as accessible as possible for the general public. This means making government data and information available to the public
-        </p>
-        <p>
-            For additionnal information on <a href="https://open.canada.ca/en/maps/open-data-canada">open governments across Canada</a>
-        </p>
-    </div>
+    <div class="col-md-12">
+        <section class="panel panel-info">
+          <header class="panel-heading">
+            <a href="https://open.canada.ca/en" class="panel-design"><h5 class="panel-title">Open Government Canada</h5></a>
+          </header>
+          <div class="panel-body">
+            <p><strong>Organization:</strong> Government of Canada</p>
+            <p><strong>Description:</strong> Portal that provides general information on Open Government in Canada and gives access to Open Data, Open Information and Open Dialogue databases.</p>
+            <p><strong>Link:</strong> <a href="https://open.canada.ca/en" target="_blank">https://open.canada.ca/en</a></p>
+          </div>
+        </section>
+      </div>
     
-    <div class="row profile">
-        <div class="col-md-12"><h3 property="name">Federal Science Library</h3></div>    
-        <p>The <strong><a href="https://science-libraries.canada.ca/eng/home/">Federal Science Library</a></strong> allows the public to access the libraries of 7 science-based departments and agencies from one portal.
-        It includes the libraries of Agriculture and Agri-Food Canada (AAFC), Environment and Climate Change Canada (ECCC), Fisheries and Oceans Canada (DFO), Health Canada (HC), the National Research Council Canada (NRC), Natural Resources Canada (NRCan)
-        and the Public Health Agency of Canada (PHAC)</p>
-    </div>
+    
+    <div class="col-md-12">
+        <section class="panel panel-info">
+          <header class="panel-heading">
+            <a href="https://open.canada.ca/en/maps/open-data-canada" class="panel-design"><h5 class="panel-title">Open data portals for Canadian administations</h5></a>
+          </header>
+          <div class="panel-body">
+            <p><strong>Organizations:</strong> Administrations across Canada</p>
+            <p><strong>Description:</strong> A list of open data portals for administrations at all levels across Canada.</p>
+            <p><strong>Link:</strong> <a href="https://open.canada.ca/en/maps/open-data-canada" target="_blank">https://open.canada.ca/en/maps/open-data-canada</a></p>
+          </div>
+        </section>
+      </div>
+
+      <div class="col-md-12">
+        <section class="panel panel-info">
+          <header class="panel-heading">
+            <a href="https://science-libraries.canada.ca/eng/home/" class="panel-design"><h5 class="panel-title">Federal Science Library</h5></a>
+          </header>
+          <div class="panel-body">
+            <p><strong>Organizations:</strong> 
+                <ul>
+                    <li><a href="http://www.agr.gc.ca/eng/home/?id=1395690825741">Agriculture and Agri-Food Canada</a></li>
+                    <li><a href="https://www.canada.ca/en/environment-climate-change.html">Environment and Climate Change Canada</a></li>
+                    <li><a href="https://www.dfo-mpo.gc.ca/index-eng.htm">Fisheries and Oceans Canada</a></li>
+                    <li><a href="https://www.canada.ca/en/health-canada.html">Health Canada</a></li>
+                    <li><a href="https://nrc.canada.ca/en">National Research Council Canada</a></li>
+                    <li><a href="https://www.nrcan.gc.ca/home">Natural Resources Canada</a></li>
+                    <li><a href="https://www.canada.ca/en/public-health.html">Public Health Agency of Canada</a></li>
+                </ul>
+            </p>
+            <p><strong>Description:</strong> The Federal Science Library gives the public access to the libraries of all the above administrations from one portal.</p>
+            <p><strong>Link:</strong> <a href="https://science-libraries.canada.ca/eng/home/" target="_blank">https://science-libraries.canada.ca/eng/home/</a></p>
+          </div>
+        </section>
+      </div>
 </div>

--- a/_pages/en/open-portal.html
+++ b/_pages/en/open-portal.html
@@ -7,7 +7,7 @@ permalink: en/open-portal.html
 
 <div class="row profile">
     <div class="col-md-12">
-        <h1 property="name"id="#wb-cont">Open Portals</h1> 
+        <h1 property="name" id="wb-cont">Open Portals</h1> 
     </div>
 
     <div class="row profile">

--- a/_pages/en/open-portal.html
+++ b/_pages/en/open-portal.html
@@ -1,0 +1,25 @@
+---
+layout: default
+ref: openPortal
+lang: en
+permalink: en/open-portal.html
+---
+
+<div class="row profile">
+    <div class="col-md-12">
+        <h1 property="name">Open Portals</h1> 
+    </div>
+
+    <div class="row profile">
+        <div class="col-md-12"><h3 property="name">Open Government</h3></div>    
+        <p><strong><a href="https://open.canada.ca/en">Open Government</a></strong> aims to have government be as accessible as possible for the general public. This means making government data and information available to the public
+        </p>
+    </div>
+    
+    <div class="row profile">
+        <div class="col-md-12"><h3 property="name">Federal Science Library</h3></div>    
+        <p>The <strong><a href="https://science-libraries.canada.ca/eng/home/">Federal Science Library</a></strong> allows the public to access the libraries of 7 science-based departments and agencies from one portal.
+        It includes the libraries of Agriculture and Agri-Food Canada (AAFC), Environment and Climate Change Canada (ECCC), Fisheries and Oceans Canada (DFO), Health Canada (HC), the National Research Council Canada (NRC), Natural Resources Canada (NRCan)
+        and the Public Health Agency of Canada (PHAC)</p>
+    </div>
+</div>

--- a/_pages/en/open-portal.html
+++ b/_pages/en/open-portal.html
@@ -14,6 +14,9 @@ permalink: en/open-portal.html
         <div class="col-md-12"><h3 property="name">Open Government</h3></div>    
         <p><strong><a href="https://open.canada.ca/en">Open Government</a></strong> aims to have government be as accessible as possible for the general public. This means making government data and information available to the public
         </p>
+        <p>
+            For additionnal information on <a href="https://open.canada.ca/en/maps/open-data-canada">open governments across Canada</a>
+        </p>
     </div>
     
     <div class="row profile">

--- a/_pages/en/open-portal.html
+++ b/_pages/en/open-portal.html
@@ -7,7 +7,7 @@ permalink: en/open-portal.html
 
 <div class="row profile">
     <div class="col-md-12">
-        <h1 property="name"id="wb-cont">Open Portals</h1> 
+        <h1 property="name"id="#wb-cont">Open Portals</h1> 
     </div>
 
     <div class="row profile">

--- a/_pages/en/open-portal.html
+++ b/_pages/en/open-portal.html
@@ -42,7 +42,7 @@ permalink: en/open-portal.html
             <a href="https://science-libraries.canada.ca/eng/home/" class="panel-design"><h5 class="panel-title">Federal Science Library</h5></a>
           </header>
           <div class="panel-body">
-            <p><strong>Organizations:</strong> 
+            <p><strong>Organizations:</strong> </p>
                 <ul>
                     <li><a href="http://www.agr.gc.ca/eng/home/?id=1395690825741">Agriculture and Agri-Food Canada</a></li>
                     <li><a href="https://www.canada.ca/en/environment-climate-change.html">Environment and Climate Change Canada</a></li>
@@ -52,7 +52,6 @@ permalink: en/open-portal.html
                     <li><a href="https://www.nrcan.gc.ca/home">Natural Resources Canada</a></li>
                     <li><a href="https://www.canada.ca/en/public-health.html">Public Health Agency of Canada</a></li>
                 </ul>
-            </p>
             <p><strong>Description:</strong> The Federal Science Library gives the public access to the libraries of all the above administrations from one portal.</p>
             <p><strong>Link:</strong> <a href="https://science-libraries.canada.ca/eng/home/" target="_blank">https://science-libraries.canada.ca/eng/home/</a></p>
           </div>

--- a/_pages/fr/index.html
+++ b/_pages/fr/index.html
@@ -115,8 +115,9 @@ permalink: /fr/index.html
       </li>
       <li>
         <details open>
-          <summary>Portails ouverts des administrations publiques canadiennes</summary>
-          Consultez la liste des <a href="./portail-ouvert.html">portails ouverts des administrations publiques canadiennes</a> pour trouvez d'autres portails ouverts 
+          <summary>Liste des portails ouverts des administrations publiques canadiennes</summary>
+          Les administrations publiques canadiennes ont créées des portails ouverts pour faciliter l'accès à leurs données et informations.
+          Consultez la <a href="./portail-ouvert.html">liste des portails ouverts des administrations publiques canadiennes</a> pour trouver les portails ouverts disponibles.
         </details>
       </li>
     </ul>

--- a/_pages/fr/index.html
+++ b/_pages/fr/index.html
@@ -113,6 +113,12 @@ permalink: /fr/index.html
             Des administrations gouvernementales à travers le monde ont aussi pris l’initiative de développer des plateformes de collaboration et de partage de solutions numériques ouvertes entre plusieurs unités administratives du pays ou de la région dans laquelle elles se situent. Pour plus d’informations, consultez la liste non-exhaustive de <a href="./catalogue.html">catalogues internationaux pour les solutions ouvertes</a>.
         </details>
       </li>
+      <li>
+        <details open>
+          <summary>Portails ouverts des administrations publiques canadiennes</summary>
+          Consultez la liste des <a href="./portail-ouvert.html">portails ouverts des administrations publiques canadiennes</a> pour trouvez d'autres portails ouverts 
+        </details>
+      </li>
     </ul>
   </div>
 </div>

--- a/_pages/fr/portail-ouvert.html
+++ b/_pages/fr/portail-ouvert.html
@@ -7,7 +7,7 @@ permalink: fr/portail-ouvert.html
 
 <div class="row profile">
     <div class="col-md-12">
-        <h1 property="name"id="#wb-cont">Portails Ouverts</h1> 
+        <h1 property="name" id="wb-cont">Portails Ouverts</h1> 
     </div>
     <div class="row profile">
         <div class="col-md-12"><h3 property="name">Gouvernement Ouvert</h3></div>    

--- a/_pages/fr/portail-ouvert.html
+++ b/_pages/fr/portail-ouvert.html
@@ -42,7 +42,7 @@ permalink: fr/portail-ouvert.html
                 <a href="https://science-libraries.canada.ca/fra/accueil/" class="panel-design"><h5 class="panel-title">Bibliothèque Scientifique Fédérale</h5></a>
               </header>
               <div class="panel-body">
-                <p><strong>Organisations:</strong> 
+                <p><strong>Organisations:</strong></p>
                     <ul>
                         <li><a href="http://www.agr.gc.ca/fra/accueil/?id=1395690825741">Agriculture et Agroalimentaire Canada</a></li>
                         <li><a href="https://www.canada.ca/fr/environnement-changement-climatique.html">Environnement et Changement climatique Canada</a></li>
@@ -52,7 +52,6 @@ permalink: fr/portail-ouvert.html
                         <li><a href="https://www.rncan.gc.ca/accueil">Ressources naturelles Canada</a></li>
                         <li><a href="https://www.canada.ca/fr/sante-publique.html">Agence de la santé publique du Canada</a></li>
                     </ul>
-                </p>
                 <p><strong>Description:</strong> La Bibliothèque Scientifique Fédérale donne accès au public aux bibliothèques des administrations mentionnées plus haut à partir d'un seul portail.</p>
                 <p><strong>Lien:</strong> <a href="https://science-libraries.canada.ca/fra/accueil/" target="_blank">https://science-libraries.canada.ca/fra/accueil/</a></p>
               </div>

--- a/_pages/fr/portail-ouvert.html
+++ b/_pages/fr/portail-ouvert.html
@@ -7,7 +7,7 @@ permalink: fr/portail-ouvert.html
 
 <div class="row profile">
     <div class="col-md-12">
-        <h1 property="name">Portails Ouverts</h1> 
+        <h1 property="name"id="wb-cont">Portails Ouverts</h1> 
     </div>
     <div class="row profile">
         <div class="col-md-12"><h3 property="name">Gouvernement Ouvert</h3></div>    

--- a/_pages/fr/portail-ouvert.html
+++ b/_pages/fr/portail-ouvert.html
@@ -12,7 +12,7 @@ permalink: fr/portail-ouvert.html
     <div class="row profile">
         <div class="col-md-12"><h3 property="name">Gouvernement Ouvert</h3></div>    
     
-        <p>Le <strong><a href="https://open.canada.ca/fr">Gouvernement Ouvert </a></strong> vise a avoir un gouvernement plus accessible au public. C'est fait en donnant plus d'accès aux données et informations gouvernementales
+        <p>Le <strong><a href="https://open.canada.ca/fr">Gouvernement Ouvert </a></strong> vise à avoir un gouvernement plus accessible au public. C'est fait en donnant plus d'accès aux données et informations gouvernementales
         </p>
         <p>
             Pour plus d'informations concernant les <a href="https://ouvert.canada.ca/fr/cartes/donnees-ouvertes-au-canada">gouvernements ouverts à travers le Canada</a>

--- a/_pages/fr/portail-ouvert.html
+++ b/_pages/fr/portail-ouvert.html
@@ -14,6 +14,9 @@ permalink: fr/portail-ouvert.html
     
         <p>Le <strong><a href="https://open.canada.ca/fr">Gouvernement Ouvert </a></strong> vise a avoir un gouvernement plus accessible au public. C'est fait en donnant plus d'accès aux données et informations gouvernementales
         </p>
+        <p>
+            Pour plus d'informations concernant les <a href="https://ouvert.canada.ca/fr/cartes/donnees-ouvertes-au-canada">gouvernements ouverts à travers le Canada</a>
+        </p>
     </div>
     <div class="row profile">
         <div class="col-md-12"><h3 property="name">Bibliothèque Scientifique Fédérale</h3></div>    

--- a/_pages/fr/portail-ouvert.html
+++ b/_pages/fr/portail-ouvert.html
@@ -7,7 +7,7 @@ permalink: fr/portail-ouvert.html
 
 <div class="row profile">
     <div class="col-md-12">
-        <h1 property="name"id="wb-cont">Portails Ouverts</h1> 
+        <h1 property="name"id="#wb-cont">Portails Ouverts</h1> 
     </div>
     <div class="row profile">
         <div class="col-md-12"><h3 property="name">Gouvernement Ouvert</h3></div>    

--- a/_pages/fr/portail-ouvert.html
+++ b/_pages/fr/portail-ouvert.html
@@ -9,19 +9,53 @@ permalink: fr/portail-ouvert.html
     <div class="col-md-12">
         <h1 property="name" id="wb-cont">Portails Ouverts</h1> 
     </div>
-    <div class="row profile">
-        <div class="col-md-12"><h3 property="name">Gouvernement Ouvert</h3></div>    
+        <div class="col-md-12">
+            <section class="panel panel-info">
+              <header class="panel-heading">
+                <a href="https://open.canada.ca/fr" class="panel-design"><h5 class="panel-title">Gouvernement Ouvert du Canada</h5></a>
+              </header>
+              <div class="panel-body">
+                <p><strong>Organisation:</strong> Gouvernement du Canada</p>
+                <p><strong>Description:</strong> Portail qui fourni des informations générales sur le gouvernement ouvert et donne accès au bases de données pour les données ouvertes, l'information ouverte et le dialogue ouvert.</p>
+                <p><strong>Lien:</strong> <a href="https://open.canada.ca/fr" target="_blank">https://open.canada.ca/fr</a></p>
+              </div>
+            </section>
+          </div>
+        
+        
+        <div class="col-md-12">
+            <section class="panel panel-info">
+              <header class="panel-heading">
+                <a href="https://ouvert.canada.ca/fr/cartes/donnees-ouvertes-au-canada" class="panel-design"><h5 class="panel-title">Open data portals for Canadian administations</h5></a>
+              </header>
+              <div class="panel-body">
+                <p><strong>Organisations:</strong> Administrations à travers le Canada</p>
+                <p><strong>Description:</strong> Une liste des portails de données ouvertes des administrations à tous les niveaux à travers le Canada.</p>
+                <p><strong>Lien:</strong> <a href="https://ouvert.canada.ca/fr/cartes/donnees-ouvertes-au-canada" target="_blank">https://ouvert.canada.ca/fr/cartes/donnees-ouvertes-au-canada</a></p>
+              </div>
+            </section>
+          </div>
     
-        <p>Le <strong><a href="https://open.canada.ca/fr">Gouvernement Ouvert </a></strong> vise à avoir un gouvernement plus accessible au public. C'est fait en donnant plus d'accès aux données et informations gouvernementales
-        </p>
-        <p>
-            Pour plus d'informations concernant les <a href="https://ouvert.canada.ca/fr/cartes/donnees-ouvertes-au-canada">gouvernements ouverts à travers le Canada</a>
-        </p>
-    </div>
-    <div class="row profile">
-        <div class="col-md-12"><h3 property="name">Bibliothèque Scientifique Fédérale</h3></div>    
-        <p>La <strong><a href="https://science-libraries.canada.ca/fra/accueil/">Bibliothèque Scientifique Fédérale</a></strong> permet au public d'accéder aux bibliothèques de sept ministères et organismes à vocation scientifiques à partir d'un seul portail.
-        Elle inclue les bibliothèque de l'Agence de la santé publique du Canada (ASPC), Agriculture et Agroalimentaire Canada (AAC), le Conseil national de recherches Canada (CNRC), Environnement et Changement climatique Canada (ECCC),
-        Pêches et Océans Canada (MPO), Ressources naturelles Canada (RNCan) et Santé Canada (SC)</p>
-    </div>    
+          <div class="col-md-12">
+            <section class="panel panel-info">
+              <header class="panel-heading">
+                <a href="https://science-libraries.canada.ca/fra/accueil/" class="panel-design"><h5 class="panel-title">Bibliothèque Scientifique Fédérale</h5></a>
+              </header>
+              <div class="panel-body">
+                <p><strong>Organisations:</strong> 
+                    <ul>
+                        <li><a href="http://www.agr.gc.ca/fra/accueil/?id=1395690825741">Agriculture et Agroalimentaire Canada</a></li>
+                        <li><a href="https://www.canada.ca/fr/environnement-changement-climatique.html">Environnement et Changement climatique Canada</a></li>
+                        <li><a href="https://www.dfo-mpo.gc.ca/index-fra.htm">Pêches et Océans Canada</a></li>
+                        <li><a href="https://www.canada.ca/fr/sante-canada.html">Santé Canada</a></li>
+                        <li><a href="https://nrc.canada.ca/fr">Conseil national de recherches Canada</a></li>
+                        <li><a href="https://www.rncan.gc.ca/accueil">Ressources naturelles Canada</a></li>
+                        <li><a href="https://www.canada.ca/fr/sante-publique.html">Agence de la santé publique du Canada</a></li>
+                    </ul>
+                </p>
+                <p><strong>Description:</strong> La Bibliothèque Scientifique Fédérale donne accès au public aux bibliothèques des administrations mentionnées plus haut à partir d'un seul portail.</p>
+                <p><strong>Lien:</strong> <a href="https://science-libraries.canada.ca/fra/accueil/" target="_blank">https://science-libraries.canada.ca/fra/accueil/</a></p>
+              </div>
+            </section>
+          </div>
 </div>

--- a/_pages/fr/portail-ouvert.html
+++ b/_pages/fr/portail-ouvert.html
@@ -1,0 +1,24 @@
+---
+layout: default
+ref: openPortal
+lang: fr
+permalink: fr/portail-ouvert.html
+---
+
+<div class="row profile">
+    <div class="col-md-12">
+        <h1 property="name">Portails Ouverts</h1> 
+    </div>
+    <div class="row profile">
+        <div class="col-md-12"><h3 property="name">Gouvernement Ouvert</h3></div>    
+    
+        <p>Le <strong><a href="https://open.canada.ca/fr">Gouvernement Ouvert </a></strong> vise a avoir un gouvernement plus accessible au public. C'est fait en donnant plus d'accès aux données et informations gouvernementales
+        </p>
+    </div>
+    <div class="row profile">
+        <div class="col-md-12"><h3 property="name">Bibliothèque Scientifique Fédérale</h3></div>    
+        <p>La <strong><a href="https://science-libraries.canada.ca/fra/accueil/">Bibliothèque Scientifique Fédérale</a></strong> permet au public d'accéder aux bibliothèques de sept ministères et organismes à vocation scientifiques à partir d'un seul portail.
+        Elle inclue les bibliothèque de l'Agence de la santé publique du Canada (ASPC), Agriculture et Agroalimentaire Canada (AAC), le Conseil national de recherches Canada (CNRC), Environnement et Changement climatique Canada (ECCC),
+        Pêches et Océans Canada (MPO), Ressources naturelles Canada (RNCan) et Santé Canada (SC)</p>
+    </div>    
+</div>


### PR DESCRIPTION
Added link to open-portal page under Open Source In Government. open-portal contains both links mentioned in Issue #831 and a link to the open governments across canada page from open.canada.ca since it's easier than maintaining the same list