### PR TITLE
Problem fixed of URL on multiple lines in YAML have space in HTML #836

### DIFF
--- a/_data/standard/utf-8.yml
+++ b/_data/standard/utf-8.yml
@@ -50,8 +50,13 @@ administrations:
       metadataLastUpdated: '2019-12-09'
     references:
       - URL:
-          en: 'https://www.bac-lac.gc.ca/eng/services/government-information-resources/guidelines/Pages/guidelines-file-formats-transferring-information-resources-enduring-value.aspx'
-          fr: 'https://www.bac-lac.gc.ca/fra/services/gestion-ressources-documentaires-gouvernement/lignes-directrices/Pages/lignes-directrices-formats-fichier-transferers-ressources-documentaires.aspx'
+          en:
+            "http://www.bac-lac.gc.ca/eng/services/government-information-resources/\
+            guidelines/Pages/guidelines-file-formats-transferring-information-resources-enduring-value.aspx"
+          fr:
+            "https://www.bac-lac.gc.ca/fra/services/gestion-ressources-documentaires-gouvernement/\
+            lignes-directrices/Pages/lignes-directrices-formats-fichier-transferers-ressources\
+            -documentaires.aspx"
         name:
           en: >-
             Guidelines on File Formats for Transferring Information Resources of


### PR DESCRIPTION
Solve problem of Long URLs split on multiple lines in YAML.