### PR TITLE
feat: Mirror English content to French repo

### DIFF
--- a/.github/workflows/sync-french.yml
+++ b/.github/workflows/sync-french.yml
@@ -1,0 +1,33 @@
+name: Mirror Content to French repo
+
+on: 
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Main repo
+      uses: actions/checkout@v2
+      with:
+        path: english
+    - name: Checkout French mirror
+      uses: actions/checkout@v2
+      with:
+        repository: canada-ca/ore-ero-fr
+        path:  french
+        ref: mirror
+        token: ${{ secrets.PUSH_API_TOKEN }}
+    - name: Copy files from English to French
+      run: rsync -avr --exclude=*.git/* --exclude=*.github/* --exclude='*/CNAME' english french
+    - name: Push back changes to French repo
+      run: |
+        cd french
+        git config --global user.email "canada.pr.bot@gmail.com"
+        git config --global user.name "canada-bot"
+        git commit --amend --no-edit
+        git push -f || fatal "Error pushing the French Mirror"


### PR DESCRIPTION
Copies English site content to French mirror repo.
If this lands, there are some other things to consider:
- [ ] Point the FR repo's  gh-pages branch to `mirror`. I avoided using `master` so that it wouldn't trigger a build over on that side. I've also disabled Actions there so it shouldn't matter
- [ ] figure out what account should have generated the PAT. Right now it's just a public repo scoped token
- [ ] Decide if we want to just use Travis instead https://docs.travis-ci.com/user/deployment/pages/

Fixes #988