### PR TITLE
chore: Swap from python HTML check to Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby
       uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.6.x
 
     - name: Install Ruby dependencies
       run: |
@@ -37,6 +35,12 @@ jobs:
     - name: Run HTMLProofer
       run: htmlproofer --disable-external --allow-hash-href ./_site
 
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v1.4.3
+
+    - name: Install NPM dependencies
+      run: npm ci
+
     - name: Run HTML5 Validator
-      run: html5validator --root _site/
+      run: npm run lint:html
       

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -34,4 +34,4 @@ jobs:
       run: npm ci
 
     - name: Run Node tests
-      run: npm test
+      run: npm run lint:js

--- a/package-lock.json
+++ b/package-lock.json
@@ -2949,6 +2949,12 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vnu-jar": {
+      "version": "20.6.30",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-20.6.30.tgz",
+      "integrity": "sha512-zlNNe7jW6cTIrxVlZK9AcZiNWjxzjqi7LpTafBCi4OY4bsh2uyGhxXT2l6hZ3ibpxP0ZC/pQsBpFQEACS0ePIg==",
+      "dev": true
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Open Resource Exchange - Échange de ressources ouvert",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint assets/js/src/**",
+    "lint": "npm run lint:js && npm run lint:html",
+    "lint:html": "java -jar node_modules/vnu-jar/build/dist/vnu.jar --errors-only --no-langdetect --skip-non-html _site/",
+    "lint:js": "eslint assets/js/src/**",
     "open-licences": "licensee --errors-only",
     "prettify": "eslint assets/js/src/** --fix",
     "test": "npm run lint && npm run open-licences",
@@ -31,7 +33,8 @@
     "eslint": "^7.2.0",
     "eslint-plugin-prettier": "^3.1.3",
     "licensee": "^8.0.2",
-    "prettier": "^2.0.5"
+    "prettier": "^2.0.5",
+    "vnu-jar": "^20.6.30"
   },
   "dependencies": {}
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-html5validator==0.3.3
 yamale==2.2.0
 yamllint==1.23.0


### PR DESCRIPTION
The python version is failing due to some Java issues. The NPM version is maintained by the upstream java library used by both and works with the current Java version on the runners