### PR TITLE
fix: Sort dependency mult-key

### DIFF
--- a/assets/py/dependenciesParser.py
+++ b/assets/py/dependenciesParser.py
@@ -26,7 +26,7 @@ def createDirectory(dir, path):
 def updateData(dependencies):
     with open("./_data/dependencies.yaml", 'w') as file:
         file.write("---")
-        dependencies.sort(key=lambda item: item.get("dependency"), reverse=False)
+        dependencies.sort(key=lambda item: f'{item.get("dependency").lower()}~{item.get("origin")}~{item.get("type")}', reverse=False)
         for value in dependencies:
             if '@' in value["dependency"]:
                 file.write("\n" + "- dependency: '" + value["dependency"] + "'")


### PR DESCRIPTION
Noticed there was still some diff noise, because some dependencies are showing up under core and dev