### PR TITLE
chore: Add cypress testing to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,8 @@ jobs:
 
       - name: Run HTML5 Validator
         run: npm run lint:html
+
+      - name: Run Cypress tests
+        run: |
+          bundle exec jekyll serve --detach
+          npm run cypress:run

--- a/_config.yml
+++ b/_config.yml
@@ -18,3 +18,10 @@ excludeTag: "Exclude-Exclure"
 # Build settings
 markdown: kramdown
 include: ["_pages", "_json"]
+exclude:
+  - "cypress"
+  - "node_modules"
+  - "*.md"
+  - "Gemfile*"
+  - "package*.json"
+  - "requirements.txt"

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "Open Resource Exchange - Échange de ressources ouvert",
   "main": "index.js",
   "scripts": {
+    "cypress:open": "cypress open",
+    "cypress:run": "cypress run",
     "lint": "npm run lint:js && npm run lint:html",
     "lint:html": "java -jar node_modules/vnu-jar/build/dist/vnu.jar --errors-only --no-langdetect --skip-non-html _site/",
     "lint:js": "eslint assets/js/src/**",
     "open-licences": "licensee --errors-only",
     "prettify": "eslint assets/js/src/** --fix",
-    "test": "npm run lint && npm run open-licences",
-    "cypress:open": "cypress open"
+    "test": "npm run lint && npm run open-licences"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Plug the Cypress testing into the CI pipeline to version bumps can be tested for breakage