### PR TITLE
Add Department of Justice to Federal administrations

### DIFF
--- a/_data/administrations/federal.yml
+++ b/_data/administrations/federal.yml
@@ -174,3 +174,8 @@
     en: Canadian Transportation Agency
     fr: Office des transports du Canada
   email_suffix:
+- code: justice
+  name:
+    en: Department of Justice
+    fr: Ministère de la Justice
+  email_suffix:


### PR DESCRIPTION
Someone from Justice is trying to add an entry to open source code using the form, but was unable to Add a new administration because Federal is grayed out when selecting the Level of government.

Adding it here derectly to help