### PR TITLE
Fix footer svg bug and upgrade WET

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,9 +1,8 @@
 ---
 permalink: /404.html
 ---
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html>
 <html class="no-js" lang="en" dir="ltr">
-<!--<![endif]-->
 <head>
 <meta charset="utf-8">
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)

--- a/404.html
+++ b/404.html
@@ -13,16 +13,10 @@ permalink: /404.html
 <!-- Meta data -->
 <meta name="robots" content="noindex, nofollow, noarchive">
 <!-- Meta data-->
-<!--[if gte IE 9 | !IE ]><!-->
+
 <link href="{{ site.wet_cdts_hosturl }}/assets/favicon.ico" rel="icon" type="image/x-icon">
 <link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/theme-srv.min.css">
-<!--<![endif]-->
-<!--[if lt IE 9]>
-		<link href="{{ site.wet_cdts_hosturl }}/assets/favicon.ico" rel="shortcut icon" />
-		<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}w/css/ie8-theme-srv.min.css" />
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
-		<script src="{{ site.wet_cdts_hosturl }}/js/ie8-wet-boew.min.js"></script>
-		<![endif]-->
+
 <noscript><link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/noscript.min.css" /></noscript>
 </head>
 <body vocab="http://schema.org/" typeof="WebPage">
@@ -55,14 +49,9 @@ permalink: /404.html
 </section>
 </div>
 </main>
-<!--[if gte IE 9 | !IE ]><!-->
+
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
 <script src="{{ site.wet_cdts_hosturl }}/js/wet-boew.min.js"></script>
-<!--<![endif]-->
-<!--[if lt IE 9]>
-		<script src="{{ site.wet_cdts_hosturl }}/js/ie8-wet-boew2.min.js"></script>
-
-		<![endif]-->
 <script src="{{ site.wet_cdts_hosturl }}/js/theme.min.js"></script>
 </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -50,7 +50,7 @@ permalink: /404.html
 </div>
 </main>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/{{ site.jquery_version }}/jquery.js"></script>
 <script src="{{ site.wet_cdts_hosturl }}/js/wet-boew.min.js"></script>
 <script src="{{ site.wet_cdts_hosturl }}/js/theme.min.js"></script>
 </body>

--- a/404.html
+++ b/404.html
@@ -14,25 +14,25 @@ permalink: /404.html
 <meta name="robots" content="noindex, nofollow, noarchive">
 <!-- Meta data-->
 <!--[if gte IE 9 | !IE ]><!-->
-<link href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/favicon.ico" rel="icon" type="image/x-icon">
-<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/theme-srv.min.css">
+<link href="{{ site.wet_cdts_hosturl }}/assets/favicon.ico" rel="icon" type="image/x-icon">
+<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/theme-srv.min.css">
 <!--<![endif]-->
 <!--[if lt IE 9]>
-		<link href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/favicon.ico" rel="shortcut icon" />
+		<link href="{{ site.wet_cdts_hosturl }}/assets/favicon.ico" rel="shortcut icon" />
 		<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}w/css/ie8-theme-srv.min.css" />
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.js"></script>
-		<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/ie8-wet-boew.min.js"></script>
+		<script src="{{ site.wet_cdts_hosturl }}/js/ie8-wet-boew.min.js"></script>
 		<![endif]-->
-<noscript><link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/noscript.min.css" /></noscript>
+<noscript><link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/noscript.min.css" /></noscript>
 </head>
 <body vocab="http://schema.org/" typeof="WebPage">
 <header role="banner" id="wb-bnr" class="container">
 <div class="row">
 <div class="col-sm-6">
-<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/sig-blk-en.svg" aria-label="Government of Canada / Gouvernement du Canada"></object>
+<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{ site.wet_cdts_hosturl }}/assets/sig-blk-en.svg" aria-label="Government of Canada / Gouvernement du Canada"></object>
 </div>
 <div class="col-sm-6">
-<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/wmms-blk.svg" aria-label="Symbol of the Government of Canada"></object>
+<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{ site.wet_cdts_hosturl }}/assets/wmms-blk.svg" aria-label="Symbol of the Government of Canada"></object>
 </div>
 </div>
 </header>
@@ -57,12 +57,12 @@ permalink: /404.html
 </main>
 <!--[if gte IE 9 | !IE ]><!-->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
-<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/wet-boew.min.js"></script>
+<script src="{{ site.wet_cdts_hosturl }}/js/wet-boew.min.js"></script>
 <!--<![endif]-->
 <!--[if lt IE 9]>
-		<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/ie8-wet-boew2.min.js"></script>
+		<script src="{{ site.wet_cdts_hosturl }}/js/ie8-wet-boew2.min.js"></script>
 
 		<![endif]-->
-<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/theme.min.js"></script>
+<script src="{{ site.wet_cdts_hosturl }}/js/theme.min.js"></script>
 </body>
 </html>

--- a/_config.yml
+++ b/_config.yml
@@ -5,8 +5,8 @@ github_username: canada-ca
 github_repository: ore-ero
 prbot_url: "https://canada-pr-bot.herokuapp.com/"
 
-wet_cdts_hosturl: "https://www.canada.ca/etc/designs/canada/cdts/gcweb"
-wet_cdts_version: "v4_0_32c"
+wet_cdts_hosturl: "https://www.canada.ca/etc/designs/canada/wet-boew"
+jquery_version: "2.2.4"
 
 active_campaign: true
 active_campaign_name: "COVID-19"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -32,25 +32,21 @@
           <a href="#wb-cont">{{ site.data.i18n.general.footer.TopOfPage[page.lang] }} <span class="glyphicon glyphicon-chevron-up"></span></a>
         </div>
         <div class="col-xs-6 col-md-3 col-lg-2 text-right">
-          <object type="image/svg+xml" tabindex="-1" role="img" data="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/wmms-blk.svg" aria-label="{{ site.data.i18n.general.footer.Logo[page.lang] }}"></object>
+          <img src="{{ site.wet_cdts_hosturl }}/assets/wmms-blk.svg" alt="{{ site.data.i18n.general.footer.Logo[page.lang] }}"/>
         </div>
       </div>
     </div>
   </div>
 </footer>
 
-<!--[if gte IE 9 | !IE ]><!-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
-<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/wet-boew.min.js"></script>
-<!--<![endif]-->
-<!--[if lt IE 9]>
-<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/ie8-wet-boew2.min.js"></script>
-<![endif]-->
-<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/theme.min.js"></script>
-{% for script in site.data.scripts.general %}
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/{{ site.jquery_version }}/jquery.js"></script>
+<script src="{{ site.wet_cdts_hosturl }}/js/wet-boew.min.js"></script>
+<script src="{{ site.wet_cdts_hosturl }}/js/theme.min.js"></script>
+
+{%- for script in site.data.scripts.general -%}
   <script src="{{script.scope.path}}"></script>
 {% endfor %}
-{% for script in site.data.scripts[page.ref] %}
+{%- for script in site.data.scripts[page.ref] -%}
   <script src="{{script.scope.path}}"></script>
 {% endfor %}
 <script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,18 +7,11 @@
   <!-- Meta data -->
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.data.i18n.general.head.description[page.lang] }}{% endif %}">
   <!-- Meta data-->
-  <!--[if gte IE 9 | !IE ]><!-->
-  <link href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/favicon.ico" rel="icon" type="image/x-icon">
-  <link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/theme.min.css">
+
+  <link href="{{ site.wet_cdts_hosturl }}/assets/favicon.ico" rel="icon" type="image/x-icon">
+  <link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/theme.min.css">
   <link rel='stylesheet' href='https://use.fontawesome.com/releases/v5.7.0/css/all.css' integrity='sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ' crossorigin='anonymous'>
   <link rel='stylesheet' href='../assets/style.css'>
-  <!--<![endif]-->
-  <!--[if lt IE 9]>
-  <link href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/favicon.ico" rel="shortcut icon" />
-  <link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/ie8-theme.min.css" />
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-  <script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/ie8-wet-boew.min.js"></script>
-	<![endif]-->
-  <!--[if lte IE 9]> <![endif]-->
-  <noscript><link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/noscript.min.css" /></noscript>
+
+  <noscript><link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/noscript.min.css" /></noscript>
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
 <html class="no-js" lang="{{ page.lang }}" dir="ltr">
-<!--<![endif]-->
 {% include head.html %}
 <body vocab="http://schema.org/" typeof="WebPage" class="page-{{ page.ref }}">
 {% include header.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="no-js" lang="{{ page.lang }}" dir="ltr">
 {% include head.html %}
 <body vocab="http://schema.org/" typeof="WebPage" class="page-{{ page.ref }}">

--- a/index.html
+++ b/index.html
@@ -22,20 +22,20 @@ lang: en-fr
 		<meta name="dcterms.language" lang="fr" title="ISO639-2" content="fra">
 		<meta name="robots" content="noindex, follow">
 		<!--[if gte IE 9 | !IE ]><!-->
-		<link href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/favicon.ico" rel="icon" type="image/x-icon">
-		<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/theme.min.css">
+		<link href="{{ site.wet_cdts_hosturl }}/assets/favicon.ico" rel="icon" type="image/x-icon">
+		<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/theme.min.css">
 		<!--<![endif]-->
-		<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/messages.min.css">
+		<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/messages.min.css">
 		<!--[if lt IE 9]>
-				<link href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/favicon.ico" rel="shortcut icon" />
-				<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/messages-ie.min.css" />
-				<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/ie8-theme.min.css" />
+				<link href="{{ site.wet_cdts_hosturl }}/assets/favicon.ico" rel="shortcut icon" />
+				<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/messages-ie.min.css" />
+				<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/ie8-theme.min.css" />
 				<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-				<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/ie8-wet-boew.min.js"></script>
+				<script src="{{ site.wet_cdts_hosturl }}/js/ie8-wet-boew.min.js"></script>
 				<![endif]-->
 		<!--[if lte IE 9]><![endif]-->
 
-		<noscript><link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/css/noscript.min.css" /></noscript>
+		<noscript><link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/noscript.min.css" /></noscript>
 		<!-- Google Tag Manager DO NOT REMOVE OR MODIFY - NE PAS SUPPRIMER OU MODIFIER -->
 		<script>dataLayer1 = [];</script>
 		<!-- End Google Tag Manager -->
@@ -47,7 +47,7 @@ lang: en-fr
 		<!-- End Google Tag Manager -->
 
 		<div id="bg">
-			<img src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/sp-bg-2.jpg" alt="Blurry mountains / Montagnes floues">
+			<img src="{{ site.wet_cdts_hosturl }}/assets/sp-bg-2.jpg" alt="Blurry mountains / Montagnes floues">
 		</div>
 
 		<main role="main">
@@ -56,7 +56,7 @@ lang: en-fr
 					<h1 property="name" class="wb-inv">Canada-ca</h1>
 					<div class="row">
 						<div class="col-xs-11 col-md-8">
-							<img src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/sig-spl.svg" width="283" alt="Government of Canada / Gouvernement du Canada">
+							<img src="{{ site.wet_cdts_hosturl }}/assets/sig-spl.svg" width="283" alt="Government of Canada / Gouvernement du Canada">
 						</div>
 					</div>
 
@@ -80,7 +80,7 @@ lang: en-fr
 						</div>
 
 						<div class="col-xs-5 col-md-4 text-right mrgn-bttm-md">
-							<object type="image/svg+xml" tabindex="-1" role="img" data="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/wmms-spl.svg" width="127" aria-label="Symbol of the Government of Canada / Symbole du gouvernement du Canada"></object>
+              <img src="{{ site.wet_cdts_hosturl }}/assets/wmms-blk.svg" alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"/>
 						</div>
 					</div>
 				</div>
@@ -89,11 +89,11 @@ lang: en-fr
 
 		<!--[if gte IE 9 | !IE ]><!-->
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
-		<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/wet-boew.min.js"></script>
+		<script src="{{ site.wet_cdts_hosturl }}/js/wet-boew.min.js"></script>
 		<!--<![endif]-->
 		<!--[if lt IE 9]>
-			<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/ie8-wet-boew2.min.js"></script>
+			<script src="{{ site.wet_cdts_hosturl }}/js/ie8-wet-boew2.min.js"></script>
 		<![endif]-->
-		<script src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/js/theme.min.js"></script>
+		<script src="{{ site.wet_cdts_hosturl }}/js/theme.min.js"></script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,19 +21,10 @@ lang: en-fr
 		<meta name="dcterms.language" title="ISO639-2" content="eng">
 		<meta name="dcterms.language" lang="fr" title="ISO639-2" content="fra">
 		<meta name="robots" content="noindex, follow">
-		<!--[if gte IE 9 | !IE ]><!-->
+
 		<link href="{{ site.wet_cdts_hosturl }}/assets/favicon.ico" rel="icon" type="image/x-icon">
 		<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/theme.min.css">
-		<!--<![endif]-->
 		<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/messages.min.css">
-		<!--[if lt IE 9]>
-				<link href="{{ site.wet_cdts_hosturl }}/assets/favicon.ico" rel="shortcut icon" />
-				<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/messages-ie.min.css" />
-				<link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/ie8-theme.min.css" />
-				<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-				<script src="{{ site.wet_cdts_hosturl }}/js/ie8-wet-boew.min.js"></script>
-				<![endif]-->
-		<!--[if lte IE 9]><![endif]-->
 
 		<noscript><link rel="stylesheet" href="{{ site.wet_cdts_hosturl }}/css/noscript.min.css" /></noscript>
 		<!-- Google Tag Manager DO NOT REMOVE OR MODIFY - NE PAS SUPPRIMER OU MODIFIER -->
@@ -87,13 +78,8 @@ lang: en-fr
 			</div>
 		</main>
 
-		<!--[if gte IE 9 | !IE ]><!-->
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
 		<script src="{{ site.wet_cdts_hosturl }}/js/wet-boew.min.js"></script>
-		<!--<![endif]-->
-		<!--[if lt IE 9]>
-			<script src="{{ site.wet_cdts_hosturl }}/js/ie8-wet-boew2.min.js"></script>
-		<![endif]-->
 		<script src="{{ site.wet_cdts_hosturl }}/js/theme.min.js"></script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ lang: en-fr
 			</div>
 		</main>
 
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/{{ site.jquery_version }}/jquery.js"></script>
 		<script src="{{ site.wet_cdts_hosturl }}/js/wet-boew.min.js"></script>
 		<script src="{{ site.wet_cdts_hosturl }}/js/theme.min.js"></script>
 	</body>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ ref: index
 lang: en-fr
 ---
 
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html>
 <html lang="en">
 <!--<![endif]-->
 	<head>


### PR DESCRIPTION
There is currently a bug on the site that downloads the wmms-blk.svg file when loading pages on the ORE. (All pages)
To reproduce, open https://code.open.canada.ca/en/index.html using Chromium, Chrome or Edge browsers.
Firefox does not download the image, but it does not appear on pages.

Looking at the new footer on canada.ca and the design guides, I noticed that the footer image causing the issues went from an `<object>` to an `<img>`.

- Replaced objects with images (the Canada logo now appears in the footer and on the splash page)
- Removed code supporting IE8 (was also removed from canada.ca)
- Upgraded to latest version of WET (4.0.39.1) and set it to always use latest version.
  - Removed WET version from config file
- Added jQuery version to config file