### PR TITLE
chore: Bundle minor/patch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: daily
       time: "11:00"
     open-pull-requests-limit: 99
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Reduce the minor Dependabot PRs, but leave the Major version ones separate