### PR TITLE
ci: Try syncing submodules to FR repo

### DIFF
--- a/.github/workflows/sync-french.yml
+++ b/.github/workflows/sync-french.yml
@@ -1,14 +1,14 @@
 name: Mirror Content to French repo
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
-    paths:
-      - "**/*.*"
-      - "!CNAME"
-      - "!.github/**"
-      - ".github/workflows/sync-french.yml"
+    paths-ignore:
+      - "CNAME"
+      - ".github/"
+      - "!.github/workflows/sync-french.yml"
 
 jobs:
   build:
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: english
+          submodules: true
       - name: Checkout French mirror
         uses: actions/checkout@v4
         with:
@@ -27,6 +28,7 @@ jobs:
           path: french
           ref: master
           token: ${{ secrets.PUSH_API_TOKEN }}
+          submodules: true
       - name: Copy files from English to French
         run: rsync -avr --delete --exclude=*.git/* --exclude=*.github/* --exclude='*CNAME' english/ french
       - name: Push back changes to French repo


### PR DESCRIPTION
Trying to debug the failure on the French pages publishing and noticed the spdx data wasn't updating. Added the manual trigger to the workflow to try redoing it and opting in the submodule cloning